### PR TITLE
Add test for changesets loading

### DIFF
--- a/lib/mono/cli.rb
+++ b/lib/mono/cli.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "yaml"
 require "pathname"
 
 module Mono
@@ -42,7 +43,7 @@ module Mono
 
       def initialize(options = [])
         @options = options
-        @config = Config.new
+        @config = Config.new(YAML.safe_load(File.read("mono.yml")))
         package_class = PackageBase.for(config.language)
         if config.monorepo?
           packages_dir = config.packages_dir

--- a/lib/mono/config.rb
+++ b/lib/mono/config.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-require "yaml"
-
 module Mono
   class Config
-    def initialize
-      @config = YAML.safe_load(File.read("mono.yml"))
+    def initialize(config)
+      @config = config
     end
 
     def language

--- a/spec/lib/mono/changeset_collection_spec.rb
+++ b/spec/lib/mono/changeset_collection_spec.rb
@@ -1,6 +1,61 @@
 # frozen_string_literal: true
 
 RSpec.describe Mono::ChangesetCollection do
+  describe "#changesets" do
+    let(:test_project) { :nodejs_npm_mono }
+    let(:config) { config_for(test_project) }
+    let(:package) do
+      Mono::Languages::Nodejs::Package.new("package_one", "packages/package_one", config)
+    end
+    let(:collection) { described_class.new(config, package) }
+    let(:changesets) { collection.changesets }
+    before do
+      prepare_project test_project
+    end
+
+    context "without changesets" do
+      it "returns an empty array" do
+        in_project do
+          in_package :package_one do
+            expect(current_package_changeset_files).to eql([])
+          end
+
+          expect(changesets).to eql([])
+        end
+      end
+    end
+
+    context "with one changeset" do
+      it "returns an array with one changeset object" do
+        in_project do
+          in_package :package_one do
+            add_changeset :patch
+
+            expect(current_package_changeset_files.length).to eql(1)
+          end
+
+          expect(changesets.map(&:bump)).to contain_exactly("patch")
+        end
+      end
+    end
+
+    context "with multiple changesets" do
+      it "returns an array of changeset objects" do
+        in_project do
+          in_package :package_one do
+            add_changeset :patch
+            add_changeset :minor
+            add_changeset :major
+
+            expect(current_package_changeset_files.length).to eql(3)
+          end
+
+          expect(changesets.map(&:bump)).to contain_exactly("patch", "minor", "major")
+        end
+      end
+    end
+  end
+
   pending "Test different version bumps"
   pending "Test different version bumps as written to changelog file"
 end

--- a/spec/lib/mono/cli/publish_spec.rb
+++ b/spec/lib/mono/cli/publish_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Mono::Cli::Publish do
           capture_stdout do
             in_project do
               add_changeset(:patch)
-              expect(changesets.length).to eql(1)
+              expect(current_package_changeset_files.length).to eql(1)
 
               perform_commands do
                 stub_commands [/^gem push/, /^git push/] do
@@ -101,7 +101,7 @@ RSpec.describe Mono::Cli::Publish do
           capture_stdout do
             in_project do
               add_changeset(:patch)
-              expect(changesets.length).to eql(1)
+              expect(current_package_changeset_files.length).to eql(1)
 
               perform_commands do
                 stub_commands [/^mix hex.publish package --yes/, /^git push/] do
@@ -164,7 +164,7 @@ RSpec.describe Mono::Cli::Publish do
             in_project do
               in_package "package_one" do
                 add_changeset(:patch)
-                expect(changesets.length).to eql(1)
+                expect(current_package_changeset_files.length).to eql(1)
               end
 
               perform_commands do
@@ -234,7 +234,7 @@ RSpec.describe Mono::Cli::Publish do
             in_project do
               in_package "package_one" do
                 add_changeset(:patch)
-                expect(changesets.length).to eql(1)
+                expect(current_package_changeset_files.length).to eql(1)
               end
 
               perform_commands do
@@ -267,7 +267,7 @@ RSpec.describe Mono::Cli::Publish do
         in_project do
           in_package "package_one" do
             expect(File.read("package.json")).to include(%("version": "#{next_version}"))
-            expect(changesets.length).to eql(0)
+            expect(current_package_changeset_files.length).to eql(0)
 
             changelog = File.read("CHANGELOG.md")
             expect_changelog_to_include_version_header(changelog, next_version)
@@ -298,32 +298,6 @@ RSpec.describe Mono::Cli::Publish do
     pending "Ruby mono project (optional: for non Appsignal projects)"
     pending "Elixir mono project (for the future mono repo setup for Elixir)"
     pending "Node.js single project (optional: for non Appsignal projects)"
-  end
-
-  def commit_changes(message = "No message")
-    @commit_count ||= 0
-    @commit_count += 1
-    `git add . && git commit -m "Commit #{@commit_count}: #{message}"`
-  end
-
-  def add_changeset(bump)
-    @changeset_count ||= 0
-    @changeset_count += 1
-    FileUtils.mkdir_p(".changesets")
-    File.open(".changesets/#{@changeset_count}_#{bump}.md", "w+") do |file|
-      file.write(<<~CHANGESET)
-        ---
-        bump: #{bump}
-        ---
-
-        This is a #{bump} changeset bump.
-      CHANGESET
-    end
-    commit_changes("Changeset #{@changeset_count} #{bump}")
-  end
-
-  def changesets
-    Dir.glob(".changesets/*.md")
   end
 
   def expect_changelog_to_include_version_header(changelog, version)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require "mono"
 require "mono/cli"
 require "testing"
 
+ROOT_DIR = File.expand_path("..", __dir__)
 SPEC_DIR = File.expand_path(__dir__)
 Dir.glob("support/**/*.rb", :base => SPEC_DIR).sort.each do |file|
   require file
@@ -27,6 +28,7 @@ RSpec.configure do |config|
   config.include StdStreamsHelper
   config.include PathHelper
   config.include GitHelper
+  config.include ChangesetHelper
 
   config.before :suite do
     Testing.clear!

--- a/spec/support/helpers/changeset_helper.rb
+++ b/spec/support/helpers/changeset_helper.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module ChangesetHelper
+  def add_changeset(bump)
+    @changeset_count ||= 0
+    @changeset_count += 1
+    FileUtils.mkdir_p(".changesets")
+    File.open(".changesets/#{@changeset_count}_#{bump}.md", "w+") do |file|
+      file.write(<<~CHANGESET)
+        ---
+        bump: #{bump}
+        ---
+
+        This is a #{bump} changeset bump.
+      CHANGESET
+    end
+    commit_changeset("Changeset #{@changeset_count} #{bump}")
+  end
+
+  def commit_changeset(message = "No message")
+    @commit_count ||= 0
+    @commit_count += 1
+    `git add . && git commit -m "Commit #{@commit_count}: #{message}"`
+  end
+
+  def current_package_changeset_files
+    Dir.glob(".changesets/*.md")
+  end
+end

--- a/spec/support/helpers/path_helper.rb
+++ b/spec/support/helpers/path_helper.rb
@@ -50,6 +50,12 @@ module PathHelper
   end
 
   def in_package(package, &block)
-    Dir.chdir(File.join("packages", package), &block)
+    Dir.chdir(File.join("packages", package.to_s), &block)
+  end
+
+  def config_for(project)
+    Mono::Config.new(
+      YAML.safe_load(File.read(File.join(ROOT_DIR, EXAMPLES_DIR, "#{project}_project", "mono.yml")))
+    )
   end
 end


### PR DESCRIPTION
Extract changeset helpers to their own module.
Move the config loading to the CLI rather than the class initializer, so
that we can create a config class without mocking an entire project on
the file system.

[skip review]