### PR TITLE
Add VersionPromoter to bump version numbers

### DIFF
--- a/lib/mono.rb
+++ b/lib/mono.rb
@@ -4,6 +4,7 @@ module Mono
   class Error < StandardError; end
 end
 
+require "mono/version"
 require "mono/config"
 require "mono/command"
 require "mono/changeset"

--- a/lib/mono.rb
+++ b/lib/mono.rb
@@ -5,6 +5,7 @@ module Mono
 end
 
 require "mono/version"
+require "mono/version_promoter"
 require "mono/config"
 require "mono/command"
 require "mono/changeset"

--- a/lib/mono/languages/elixir/package.rb
+++ b/lib/mono/languages/elixir/package.rb
@@ -9,7 +9,7 @@ module Mono
             begin
               contents = read_mix_exs
               matches = VERSION_REGEX.match(contents)
-              Gem::Version.new(matches[1])
+              Version.parse(matches[1])
             end
         end
 

--- a/lib/mono/languages/nodejs/package.rb
+++ b/lib/mono/languages/nodejs/package.rb
@@ -11,7 +11,7 @@ module Mono
             begin
               contents = read_package_json
               matches = VERSION_REGEX.match(contents)
-              Gem::Version.new(matches[1])
+              Version.parse(matches[1])
             end
         end
 

--- a/lib/mono/languages/ruby/package.rb
+++ b/lib/mono/languages/ruby/package.rb
@@ -9,7 +9,7 @@ module Mono
             begin
               contents = read_version
               matches = VERSION_REGEX.match(contents)
-              Gem::Version.new(matches[1])
+              Version.parse_ruby(matches[1])
             end
         end
 

--- a/lib/mono/package.rb
+++ b/lib/mono/package.rb
@@ -29,8 +29,10 @@ module Mono
       @next_version ||=
         begin
           bump = changesets.next_bump
-          major, minor, patch, *_rest = current_version.canonical_segments
-          version =
+          major = current_version.major
+          minor = current_version.minor
+          patch = current_version.patch
+          version_segments =
             case bump
             when "major"
               [major + 1, 0, 0]
@@ -46,7 +48,7 @@ module Mono
               # prerelease
               raise "Unknown package bump type: #{bump}"
             end
-          Gem::Version.new(version.join("."))
+          Version.new(*version_segments)
         end
     end
 

--- a/lib/mono/version.rb
+++ b/lib/mono/version.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Mono
+  class Version
+    # Parse both formats for version numbers using prereleases.
+    # The Ruby gem uses a dot (.) between the version number and the
+    # prerelease, e.g. "1.2.3.alpha.1".
+    # The Elixir and Node.js packages use a dash (-) between the version number
+    # and the prerelease, e.g. "1.2.3-alpha.1".
+    def self.parse(string, separator: "-")
+      string = string.sub(separator, ".")
+      major, minor, patch, prerelease_type, prerelease_version =
+        Gem::Version.new(string).segments
+
+      new(
+        major,
+        minor,
+        patch,
+        prerelease_type,
+        prerelease_version,
+        :separator => separator
+      )
+    end
+
+    def self.parse_ruby(string)
+      parse(string, :separator => ".")
+    end
+
+    attr_reader :major, :minor, :patch, :prerelease_type, :prerelease_version,
+      :separator
+
+    def initialize( # rubocop:disable Metrics/ParameterLists
+      major,
+      minor,
+      patch,
+      prerelease_type = nil,
+      prerelease_version = nil,
+      separator: "-"
+    )
+      @major = major
+      @minor = minor
+      @patch = patch
+      @prerelease_type = prerelease_type
+      @prerelease_version = prerelease_version
+      @separator = separator
+    end
+
+    def prerelease?
+      @prerelease_type && @prerelease_version
+    end
+
+    def prerelease_bump
+      return unless prerelease?
+
+      if minor == 0 && patch == 0 # rubocop:disable Style/NumericPredicate
+        # For example: "3.0.0"
+        :major
+      elsif patch == 0 # rubocop:disable Style/NumericPredicate
+        # For example: "3.2.0"
+        :minor
+      else
+        # For example: "3.2.1"
+        :patch
+      end
+    end
+
+    def to_s
+      base = [major, minor, patch].join(".")
+      if prerelease?
+        "#{base}#{separator}#{prerelease_type}.#{prerelease_version}"
+      else
+        base
+      end
+    end
+  end
+end

--- a/lib/mono/version.rb
+++ b/lib/mono/version.rb
@@ -72,5 +72,26 @@ module Mono
         base
       end
     end
+
+    # Returns segments of the version object
+    #
+    # When a version has no prerelease information (alpha/beta/rc) the last two
+    # elements are omitted.
+    #
+    # - <Index>: Type of segment
+    # - 0: major
+    # - 1: minor
+    # - 2: patch
+    # - 3: prerelease type (alpha, beta, rc) (Optional)
+    # - 4: prerelease version number (Optional)
+    def segments
+      [
+        major,
+        minor,
+        patch,
+        prerelease_type,
+        prerelease_version
+      ].compact
+    end
   end
 end

--- a/lib/mono/version_promoter.rb
+++ b/lib/mono/version_promoter.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module Mono
+  class VersionPromoter
+    class UnsupportedDowngradeError < Mono::Error
+      def initialize(current_prerelease_type, new_prerelease_type)
+        @current_prerelease_type = current_prerelease_type
+        @new_prerelease_type = new_prerelease_type
+        super()
+      end
+
+      def message
+        current_type = @current_prerelease_type
+        new_type = @new_prerelease_type
+        <<~MESSAGE
+          Unexpected downgrade for prelease. Can't downgrade from a
+          `#{current_type}` to a `#{new_type}`.
+
+          - Current prerelease type: #{current_type}
+          - New prerelease type:     #{new_type}
+        MESSAGE
+      end
+    end
+
+    # List of prereleases _in reverse order_.
+    RELEASE_VERSIONS = %w[major minor patch].freeze
+    PRERELEASE_VERSIONS = %w[rc beta alpha].freeze
+
+    def self.promote(version, bump, prerelease_bump = nil)
+      segments =
+        if version.prerelease?
+          major, minor, patch, prerelease_type, prerelease_version =
+            if larger_bump?(version.prerelease_bump.to_s, bump.to_s)
+              promote_base(version, bump)
+            else
+              # If it currently already is a prerelease don't bump the base
+              # version. The biggest version bump is leading.
+              # Examples:
+              # - 1.2.3-alpha.1 + bump minor = 1.3.0.alpha.1 - Base bump
+              # - 2.3.0-alpha.1 + bump minor = 2.3.0.alpha.2 - No base bump
+              # - 3.0.0-alpha.1 + bump minor = 3.0.0.alpha.2 - No base bump
+              version.segments
+            end
+          prerelease =
+            if supported_prerelease_bump?(prerelease_type, prerelease_bump)
+              # Bump prerelease
+              # Examples:
+              # - alpha.1 => alpha.2
+              # - alpha.2 => alpha.3
+              # - alpha.3 => beta.1
+              # - beta.1  => rc.1
+              promote_prerelease(
+                [prerelease_type, prerelease_version],
+                prerelease_bump
+              )
+            else
+              # Error on downgrade of prerelease type.
+              # If the requested prerelease type is lower than the current
+              # prerelease type raise an error.
+              # Examples:
+              # - alpha => alpha = OK
+              # - alpha => beta  = OK
+              # - alpha => rc    = OK
+              # - beta  => alpha = ERROR
+              # - beta  => rc    = OK
+              # - rc    => alpha = ERROR
+              # - rc    => beta  = ERROR
+              # - rc    => rc    = OK
+              # If the current release is an RC and you want to release an
+              # alpha, that's not currently supported.
+              raise UnsupportedDowngradeError.new(
+                prerelease_type,
+                prerelease_bump
+              )
+            end
+          [major, minor, patch] + prerelease
+        else
+          # Normal base release
+          promote_base(version, bump)
+        end
+
+      Version.new(*segments)
+    end
+
+    def self.promote_base(version, bump)
+      major = version.major
+      minor = version.minor
+      patch = version.patch
+
+      case bump
+      when "major"
+        [major + 1, 0, 0]
+      when "minor"
+        [major, minor + 1, 0]
+      when "patch"
+        [major, minor, patch + 1]
+      end
+    end
+
+    # Allow the user to specify the type via the command line
+    # options, e.g. --prerelease beta
+    def self.promote_prerelease(prerelease_array, prerelease_bump)
+      prerelease_type, prerelease_version = prerelease_array
+
+      if prerelease_type == prerelease_bump
+        # Next prerelease of this type: Autoincrement the version number
+        [prerelease_type, prerelease_version + 1]
+      else
+        # First prerelease of this type
+        [prerelease_bump, 1]
+      end
+    end
+
+    def self.larger_bump?(current, new)
+      current_index = RELEASE_VERSIONS.index(current)
+      new_index = RELEASE_VERSIONS.index(new)
+      # Test against reverse order of array values
+      new_index < current_index
+    end
+
+    def self.supported_prerelease_bump?(current, new)
+      current_index = PRERELEASE_VERSIONS.index(current)
+      # When no current prelease is specified we support any level bump to a
+      # new kind of prerelease type
+      return true unless current_index
+
+      new_index = PRERELEASE_VERSIONS.index(new)
+      # Test against reverse order of array values
+      new_index <= current_index
+    end
+  end
+end

--- a/spec/lib/mono/version_promoter_spec.rb
+++ b/spec/lib/mono/version_promoter_spec.rb
@@ -1,0 +1,652 @@
+# frozen_string_literal: true
+
+RSpec.describe Mono::VersionPromoter do
+  def promote(version, bump, prerelease = nil)
+    version_object = Mono::Version.parse(version)
+    described_class.promote(version_object, bump, prerelease).to_s
+  end
+
+  describe ".promote" do
+    context "when promoting to a base release" do
+      context "when promoting to a major release" do
+        it "bumps to a new major version" do
+          expect(promote("1.2.3", "major")).to eql("2.0.0")
+          expect(promote("1.2.0", "major")).to eql("2.0.0")
+          expect(promote("1.0.0", "major")).to eql("2.0.0")
+        end
+      end
+
+      context "when promoting to a minor release" do
+        it "bumps to a new minor version" do
+          expect(promote("1.2.3", "minor")).to eql("1.3.0")
+          expect(promote("1.2.0", "minor")).to eql("1.3.0")
+          expect(promote("1.0.0", "minor")).to eql("1.1.0")
+        end
+      end
+
+      context "when promoting to a patch release" do
+        it "bumps to a new patch version" do
+          expect(promote("1.2.3", "patch")).to eql("1.2.4")
+          expect(promote("1.2.4", "patch")).to eql("1.2.5")
+        end
+      end
+    end
+
+    context "when promoting to prerelease" do
+      describe "bump to major version" do
+        context "with existing major release" do
+          context "with existing alpha prerelease" do
+            context "bump to alpha" do
+              it "only bumps the prerelease" do
+                expect(promote("2.0.0-alpha.1", "major", "alpha")).to eql("2.0.0-alpha.2")
+                expect(promote("2.0.0-alpha.2", "major", "alpha")).to eql("2.0.0-alpha.3")
+              end
+            end
+
+            context "bump to beta" do
+              it "only bumps the prerelease" do
+                expect(promote("2.0.0-alpha.1", "major", "beta")).to eql("2.0.0-beta.1")
+                expect(promote("2.0.0-alpha.2", "major", "beta")).to eql("2.0.0-beta.1")
+              end
+            end
+
+            context "bump to rc" do
+              it "only bumps the prerelease" do
+                expect(promote("2.0.0-alpha.1", "major", "rc")).to eql("2.0.0-rc.1")
+                expect(promote("2.0.0-alpha.2", "major", "rc")).to eql("2.0.0-rc.1")
+              end
+            end
+          end
+
+          context "with existing beta prerelease" do
+            context "bump to alpha" do
+              it { expect_downgrade_error { promote("2.0.0-beta.1", "major", "alpha") } }
+            end
+
+            context "bump to beta" do
+              it "only bumps the prerelease" do
+                expect(promote("2.0.0-beta.1", "major", "beta")).to eql("2.0.0-beta.2")
+                expect(promote("2.0.0-beta.2", "major", "beta")).to eql("2.0.0-beta.3")
+              end
+            end
+
+            context "bump to rc" do
+              it "only bumps the prelease" do
+                expect(promote("2.0.0-beta.1", "major", "rc")).to eql("2.0.0-rc.1")
+                expect(promote("2.0.0-beta.2", "major", "rc")).to eql("2.0.0-rc.1")
+              end
+            end
+          end
+
+          context "with existing rc prerelease" do
+            context "bump to alpha" do
+              it { expect_downgrade_error { promote("2.0.0-rc.1", "major", "alpha") } }
+            end
+
+            context "bump to beta" do
+              it { expect_downgrade_error { promote("2.0.0-rc.1", "major", "beta") } }
+            end
+
+            context "bump to rc" do
+              it "only bumps the prerelease" do
+                expect(promote("2.0.0-rc.1", "major", "rc")).to eql("2.0.0-rc.2")
+                expect(promote("2.0.0-rc.2", "major", "rc")).to eql("2.0.0-rc.3")
+              end
+            end
+          end
+        end
+
+        context "with existing minor release" do
+          context "with existing alpha prerelease" do
+            context "bump to alpha" do
+              it "bumps to major version and resets prerelease" do
+                expect(promote("1.2.0-alpha.1", "major", "alpha")).to eql("2.0.0-alpha.1")
+                expect(promote("1.2.0-alpha.2", "major", "alpha")).to eql("2.0.0-alpha.1")
+              end
+            end
+
+            context "bump to beta" do
+              it "bumps to major version and resets prerelease" do
+                expect(promote("1.2.0-alpha.1", "major", "beta")).to eql("2.0.0-beta.1")
+                expect(promote("1.2.0-alpha.2", "major", "beta")).to eql("2.0.0-beta.1")
+              end
+            end
+
+            context "bump to rc" do
+              it "bumps to major version and resets prerelease" do
+                expect(promote("1.2.0-alpha.1", "major", "rc")).to eql("2.0.0-rc.1")
+                expect(promote("1.2.0-alpha.2", "major", "rc")).to eql("2.0.0-rc.1")
+              end
+            end
+          end
+
+          context "with existing beta prerelease" do
+            context "bump to alpha" do
+              it "bumps to major version and resets prerelease" do
+                expect(promote("1.2.0-beta.1", "major", "alpha")).to eql("2.0.0-alpha.1")
+                expect(promote("1.2.0-beta.2", "major", "alpha")).to eql("2.0.0-alpha.1")
+              end
+            end
+
+            context "bump to beta" do
+              it "bumps to major version and resets prerelease" do
+                expect(promote("1.2.0-beta.1", "major", "beta")).to eql("2.0.0-beta.1")
+                expect(promote("1.2.0-beta.2", "major", "beta")).to eql("2.0.0-beta.1")
+              end
+            end
+
+            context "bump to rc" do
+              it "bumps to major version and resets prerelease" do
+                expect(promote("1.2.0-beta.1", "major", "rc")).to eql("2.0.0-rc.1")
+                expect(promote("1.2.0-beta.2", "major", "rc")).to eql("2.0.0-rc.1")
+              end
+            end
+          end
+
+          context "with existing rc prerelease" do
+            context "bump to alpha" do
+              it "bumps to major version and resets prerelease" do
+                expect(promote("1.2.0-rc.1", "major", "alpha")).to eql("2.0.0-alpha.1")
+                expect(promote("1.2.0-rc.2", "major", "alpha")).to eql("2.0.0-alpha.1")
+              end
+            end
+
+            context "bump to beta" do
+              it "bumps to major version and resets prerelease" do
+                expect(promote("1.2.0-beta.1", "major", "beta")).to eql("2.0.0-beta.1")
+                expect(promote("1.2.0-beta.2", "major", "beta")).to eql("2.0.0-beta.1")
+              end
+            end
+
+            context "bump to rc" do
+              it "bumps to major version and resets prerelease" do
+                expect(promote("1.2.0-rc.1", "major", "rc")).to eql("2.0.0-rc.1")
+                expect(promote("1.2.0-rc.2", "major", "rc")).to eql("2.0.0-rc.1")
+              end
+            end
+          end
+        end
+
+        context "with existing patch release" do
+          context "with existing alpha prerelease" do
+            context "bump to alpha" do
+              it "bumps to major version and resets prerelease" do
+                expect(promote("1.2.3-alpha.1", "major", "alpha")).to eql("2.0.0-alpha.1")
+                expect(promote("1.2.3-alpha.2", "major", "alpha")).to eql("2.0.0-alpha.1")
+              end
+            end
+
+            context "bump to beta" do
+              it "bumps to major version and resets prerelease" do
+                expect(promote("1.2.3-alpha.1", "major", "beta")).to eql("2.0.0-beta.1")
+                expect(promote("1.2.3-alpha.2", "major", "beta")).to eql("2.0.0-beta.1")
+              end
+            end
+
+            context "bump to rc" do
+              it "bumps to major version and resets prerelease" do
+                expect(promote("1.2.3-alpha.1", "major", "rc")).to eql("2.0.0-rc.1")
+                expect(promote("1.2.3-alpha.2", "major", "rc")).to eql("2.0.0-rc.1")
+              end
+            end
+          end
+
+          context "with existing beta prerelease" do
+            context "bump to alpha" do
+              it "bumps to major version and resets prerelease" do
+                expect(promote("1.2.3-beta.1", "major", "alpha")).to eql("2.0.0-alpha.1")
+                expect(promote("1.2.3-beta.2", "major", "alpha")).to eql("2.0.0-alpha.1")
+              end
+            end
+
+            context "bump to beta" do
+              it "bumps to major version and resets prerelease" do
+                expect(promote("1.2.3-beta.1", "major", "beta")).to eql("2.0.0-beta.1")
+                expect(promote("1.2.3-beta.2", "major", "beta")).to eql("2.0.0-beta.1")
+              end
+            end
+
+            context "bump to rc" do
+              it "bumps to major version and resets prerelease" do
+                expect(promote("1.2.3-beta.1", "major", "rc")).to eql("2.0.0-rc.1")
+                expect(promote("1.2.3-beta.2", "major", "rc")).to eql("2.0.0-rc.1")
+              end
+            end
+          end
+
+          context "with existing rc prerelease" do
+            context "bump to alpha" do
+              it "bumps to major version and resets prerelease" do
+                expect(promote("1.2.3-rc.1", "major", "alpha")).to eql("2.0.0-alpha.1")
+                expect(promote("1.2.3-rc.2", "major", "alpha")).to eql("2.0.0-alpha.1")
+              end
+            end
+
+            context "bump to beta" do
+              it "bumps to major version and resets prerelease" do
+                expect(promote("1.2.3-beta.1", "major", "beta")).to eql("2.0.0-beta.1")
+                expect(promote("1.2.3-beta.2", "major", "beta")).to eql("2.0.0-beta.1")
+              end
+            end
+
+            context "bump to rc" do
+              it "bumps to major version and resets prerelease" do
+                expect(promote("1.2.3-rc.1", "major", "rc")).to eql("2.0.0-rc.1")
+                expect(promote("1.2.3-rc.2", "major", "rc")).to eql("2.0.0-rc.1")
+              end
+            end
+          end
+        end
+      end
+      # End of bump to major
+
+      describe "bump to minor version" do
+        context "with existing major release" do
+          context "with existing alpha prerelease" do
+            context "bump to alpha" do
+              it "only bumps the prerelease" do
+                expect(promote("2.0.0-alpha.1", "minor", "alpha")).to eql("2.0.0-alpha.2")
+                expect(promote("2.0.0-alpha.2", "minor", "alpha")).to eql("2.0.0-alpha.3")
+              end
+            end
+
+            context "bump to beta" do
+              it "only bumps the prerelease" do
+                expect(promote("2.0.0-alpha.1", "minor", "beta")).to eql("2.0.0-beta.1")
+                expect(promote("2.0.0-alpha.2", "minor", "beta")).to eql("2.0.0-beta.1")
+              end
+            end
+
+            context "bump to rc" do
+              it "only bumps the prerelease" do
+                expect(promote("2.0.0-alpha.1", "minor", "rc")).to eql("2.0.0-rc.1")
+                expect(promote("2.0.0-alpha.2", "minor", "rc")).to eql("2.0.0-rc.1")
+              end
+            end
+          end
+
+          context "with existing beta prerelease" do
+            context "bump to alpha" do
+              it { expect_downgrade_error { promote("2.0.0-beta.1", "minor", "alpha") } }
+            end
+
+            context "bump to beta" do
+              it "only bumps the prerelease" do
+                expect(promote("2.0.0-beta.1", "minor", "beta")).to eql("2.0.0-beta.2")
+                expect(promote("2.0.0-beta.2", "minor", "beta")).to eql("2.0.0-beta.3")
+              end
+            end
+
+            context "bump to rc" do
+              it "only bumps the prelease" do
+                expect(promote("2.0.0-beta.1", "minor", "rc")).to eql("2.0.0-rc.1")
+                expect(promote("2.0.0-beta.2", "minor", "rc")).to eql("2.0.0-rc.1")
+              end
+            end
+          end
+
+          context "with existing rc prerelease" do
+            context "bump to alpha" do
+              it { expect_downgrade_error { promote("2.0.0-rc.1", "minor", "alpha") } }
+            end
+
+            context "bump to beta" do
+              it { expect_downgrade_error { promote("2.0.0-rc.1", "minor", "beta") } }
+            end
+
+            context "bump to rc" do
+              it "only bumps the prerelease" do
+                expect(promote("2.0.0-rc.1", "minor", "rc")).to eql("2.0.0-rc.2")
+                expect(promote("2.0.0-rc.2", "minor", "rc")).to eql("2.0.0-rc.3")
+              end
+            end
+          end
+        end
+
+        context "with existing minor release" do
+          context "with existing alpha prerelease" do
+            context "bump to alpha" do
+              it "bumps to minor version and resets prerelease" do
+                expect(promote("1.2.0-alpha.1", "minor", "alpha")).to eql("1.2.0-alpha.2")
+                expect(promote("1.2.0-alpha.2", "minor", "alpha")).to eql("1.2.0-alpha.3")
+              end
+            end
+
+            context "bump to beta" do
+              it "bumps to minor version and resets prerelease" do
+                expect(promote("1.2.0-alpha.1", "minor", "beta")).to eql("1.2.0-beta.1")
+                expect(promote("1.2.0-alpha.2", "minor", "beta")).to eql("1.2.0-beta.1")
+              end
+            end
+
+            context "bump to rc" do
+              it "bumps to minor version and resets prerelease" do
+                expect(promote("1.2.0-alpha.1", "minor", "rc")).to eql("1.2.0-rc.1")
+                expect(promote("1.2.0-alpha.2", "minor", "rc")).to eql("1.2.0-rc.1")
+              end
+            end
+          end
+
+          context "with existing beta prerelease" do
+            context "bump to alpha" do
+              it do
+                expect_downgrade_error { promote("1.2.0-beta.1", "minor", "alpha") }
+              end
+            end
+
+            context "bump to beta" do
+              it "bumps to minor version and resets prerelease" do
+                expect(promote("1.2.0-beta.1", "minor", "beta")).to eql("1.2.0-beta.2")
+                expect(promote("1.2.0-beta.2", "minor", "beta")).to eql("1.2.0-beta.3")
+              end
+            end
+
+            context "bump to rc" do
+              it "bumps to minor version and resets prerelease" do
+                expect(promote("1.2.0-beta.1", "minor", "rc")).to eql("1.2.0-rc.1")
+                expect(promote("1.2.0-beta.2", "minor", "rc")).to eql("1.2.0-rc.1")
+              end
+            end
+          end
+
+          context "with existing rc prerelease" do
+            context "bump to alpha" do
+              it "bumps to minor version and resets prerelease" do
+                expect_downgrade_error { promote("1.2.0-rc.1", "minor", "alpha") }
+              end
+            end
+
+            context "bump to beta" do
+              it "bumps to minor version and resets prerelease" do
+                expect_downgrade_error { promote("1.2.0-rc.1", "minor", "beta") }
+              end
+            end
+
+            context "bump to rc" do
+              it "only bumps prerelease" do
+                expect(promote("1.2.0-rc.1", "minor", "rc")).to eql("1.2.0-rc.2")
+                expect(promote("1.2.0-rc.2", "minor", "rc")).to eql("1.2.0-rc.3")
+              end
+            end
+          end
+        end
+
+        context "with existing patch release" do
+          context "with existing alpha prerelease" do
+            context "bump to alpha" do
+              it "bumps to minor version and resets prerelease" do
+                expect(promote("1.2.3-alpha.1", "minor", "alpha")).to eql("1.3.0-alpha.1")
+                expect(promote("1.2.3-alpha.2", "minor", "alpha")).to eql("1.3.0-alpha.1")
+              end
+            end
+
+            context "bump to beta" do
+              it "bumps to minor version and resets prerelease" do
+                expect(promote("1.2.3-alpha.1", "minor", "beta")).to eql("1.3.0-beta.1")
+                expect(promote("1.2.3-alpha.2", "minor", "beta")).to eql("1.3.0-beta.1")
+              end
+            end
+
+            context "bump to rc" do
+              it "bumps to minor version and resets prerelease" do
+                expect(promote("1.2.3-alpha.1", "minor", "rc")).to eql("1.3.0-rc.1")
+                expect(promote("1.2.3-alpha.2", "minor", "rc")).to eql("1.3.0-rc.1")
+              end
+            end
+          end
+
+          context "with existing beta prerelease" do
+            context "bump to alpha" do
+              it "bumps to minor version and resets prerelease" do
+                expect(promote("1.2.3-beta.1", "minor", "alpha")).to eql("1.3.0-alpha.1")
+                expect(promote("1.2.3-beta.2", "minor", "alpha")).to eql("1.3.0-alpha.1")
+              end
+            end
+
+            context "bump to beta" do
+              it "bumps to minor version and resets prerelease" do
+                expect(promote("1.2.3-beta.1", "minor", "beta")).to eql("1.3.0-beta.1")
+                expect(promote("1.2.3-beta.2", "minor", "beta")).to eql("1.3.0-beta.1")
+              end
+            end
+
+            context "bump to rc" do
+              it "bumps to minor version and resets prerelease" do
+                expect(promote("1.2.3-beta.1", "minor", "rc")).to eql("1.3.0-rc.1")
+                expect(promote("1.2.3-beta.2", "minor", "rc")).to eql("1.3.0-rc.1")
+              end
+            end
+          end
+
+          context "with existing rc prerelease" do
+            context "bump to alpha" do
+              it "bumps to minor version and resets prerelease" do
+                expect(promote("1.2.3-rc.1", "minor", "alpha")).to eql("1.3.0-alpha.1")
+                expect(promote("1.2.3-rc.2", "minor", "alpha")).to eql("1.3.0-alpha.1")
+              end
+            end
+
+            context "bump to beta" do
+              it "bumps to minor version and resets prerelease" do
+                expect(promote("1.2.3-beta.1", "minor", "beta")).to eql("1.3.0-beta.1")
+                expect(promote("1.2.3-beta.2", "minor", "beta")).to eql("1.3.0-beta.1")
+              end
+            end
+
+            context "bump to rc" do
+              it "bumps to minor version and resets prerelease" do
+                expect(promote("1.2.3-rc.1", "minor", "rc")).to eql("1.3.0-rc.1")
+                expect(promote("1.2.3-rc.2", "minor", "rc")).to eql("1.3.0-rc.1")
+              end
+            end
+          end
+        end
+      end
+      # End of bump to minor
+
+      describe "bump to patch version" do
+        context "with existing major release" do
+          context "with existing alpha prerelease" do
+            context "bump to alpha" do
+              it "only bumps the prerelease" do
+                expect(promote("2.0.0-alpha.1", "patch", "alpha")).to eql("2.0.0-alpha.2")
+                expect(promote("2.0.0-alpha.2", "patch", "alpha")).to eql("2.0.0-alpha.3")
+              end
+            end
+
+            context "bump to beta" do
+              it "only bumps the prerelease" do
+                expect(promote("2.0.0-alpha.1", "patch", "beta")).to eql("2.0.0-beta.1")
+                expect(promote("2.0.0-alpha.2", "patch", "beta")).to eql("2.0.0-beta.1")
+              end
+            end
+
+            context "bump to rc" do
+              it "only bumps the prerelease" do
+                expect(promote("2.0.0-alpha.1", "patch", "rc")).to eql("2.0.0-rc.1")
+                expect(promote("2.0.0-alpha.2", "patch", "rc")).to eql("2.0.0-rc.1")
+              end
+            end
+          end
+
+          context "with existing beta prerelease" do
+            context "bump to alpha" do
+              it { expect_downgrade_error { promote("2.0.0-beta.1", "patch", "alpha") } }
+            end
+
+            context "bump to beta" do
+              it "only bumps the prerelease" do
+                expect(promote("2.0.0-beta.1", "patch", "beta")).to eql("2.0.0-beta.2")
+                expect(promote("2.0.0-beta.2", "patch", "beta")).to eql("2.0.0-beta.3")
+              end
+            end
+
+            context "bump to rc" do
+              it "only bumps the prelease" do
+                expect(promote("2.0.0-beta.1", "patch", "rc")).to eql("2.0.0-rc.1")
+                expect(promote("2.0.0-beta.2", "patch", "rc")).to eql("2.0.0-rc.1")
+              end
+            end
+          end
+
+          context "with existing rc prerelease" do
+            context "bump to alpha" do
+              it { expect_downgrade_error { promote("2.0.0-rc.1", "patch", "alpha") } }
+            end
+
+            context "bump to beta" do
+              it { expect_downgrade_error { promote("2.0.0-rc.1", "patch", "beta") } }
+            end
+
+            context "bump to rc" do
+              it "only bumps the prerelease" do
+                expect(promote("2.0.0-rc.1", "patch", "rc")).to eql("2.0.0-rc.2")
+                expect(promote("2.0.0-rc.2", "patch", "rc")).to eql("2.0.0-rc.3")
+              end
+            end
+          end
+        end
+
+        context "with existing patch release" do
+          context "with existing alpha prerelease" do
+            context "bump to alpha" do
+              it "bumps to patch version and resets prerelease" do
+                expect(promote("1.2.0-alpha.1", "patch", "alpha")).to eql("1.2.0-alpha.2")
+                expect(promote("1.2.0-alpha.2", "patch", "alpha")).to eql("1.2.0-alpha.3")
+              end
+            end
+
+            context "bump to beta" do
+              it "bumps to patch version and resets prerelease" do
+                expect(promote("1.2.0-alpha.1", "patch", "beta")).to eql("1.2.0-beta.1")
+                expect(promote("1.2.0-alpha.2", "patch", "beta")).to eql("1.2.0-beta.1")
+              end
+            end
+
+            context "bump to rc" do
+              it "bumps to patch version and resets prerelease" do
+                expect(promote("1.2.0-alpha.1", "patch", "rc")).to eql("1.2.0-rc.1")
+                expect(promote("1.2.0-alpha.2", "patch", "rc")).to eql("1.2.0-rc.1")
+              end
+            end
+          end
+
+          context "with existing beta prerelease" do
+            context "bump to alpha" do
+              it do
+                expect_downgrade_error { promote("1.2.0-beta.1", "patch", "alpha") }
+              end
+            end
+
+            context "bump to beta" do
+              it "bumps to patch version and resets prerelease" do
+                expect(promote("1.2.0-beta.1", "patch", "beta")).to eql("1.2.0-beta.2")
+                expect(promote("1.2.0-beta.2", "patch", "beta")).to eql("1.2.0-beta.3")
+              end
+            end
+
+            context "bump to rc" do
+              it "bumps to patch version and resets prerelease" do
+                expect(promote("1.2.0-beta.1", "patch", "rc")).to eql("1.2.0-rc.1")
+                expect(promote("1.2.0-beta.2", "patch", "rc")).to eql("1.2.0-rc.1")
+              end
+            end
+          end
+
+          context "with existing rc prerelease" do
+            context "bump to alpha" do
+              it "bumps to patch version and resets prerelease" do
+                expect_downgrade_error { promote("1.2.0-rc.1", "patch", "alpha") }
+              end
+            end
+
+            context "bump to beta" do
+              it "bumps to patch version and resets prerelease" do
+                expect_downgrade_error { promote("1.2.0-rc.1", "patch", "beta") }
+              end
+            end
+
+            context "bump to rc" do
+              it "only bumps prerelease" do
+                expect(promote("1.2.0-rc.1", "patch", "rc")).to eql("1.2.0-rc.2")
+                expect(promote("1.2.0-rc.2", "patch", "rc")).to eql("1.2.0-rc.3")
+              end
+            end
+          end
+        end
+
+        context "with existing patch release" do
+          context "with existing alpha prerelease" do
+            context "bump to alpha" do
+              it "bumps to patch version and resets prerelease" do
+                expect(promote("1.2.3-alpha.1", "patch", "alpha")).to eql("1.2.3-alpha.2")
+                expect(promote("1.2.3-alpha.2", "patch", "alpha")).to eql("1.2.3-alpha.3")
+              end
+            end
+
+            context "bump to beta" do
+              it "bumps to patch version and resets prerelease" do
+                expect(promote("1.2.3-alpha.1", "patch", "beta")).to eql("1.2.3-beta.1")
+                expect(promote("1.2.3-alpha.2", "patch", "beta")).to eql("1.2.3-beta.1")
+              end
+            end
+
+            context "bump to rc" do
+              it "bumps to patch version and resets prerelease" do
+                expect(promote("1.2.3-alpha.1", "patch", "rc")).to eql("1.2.3-rc.1")
+                expect(promote("1.2.3-alpha.2", "patch", "rc")).to eql("1.2.3-rc.1")
+              end
+            end
+          end
+
+          context "with existing beta prerelease" do
+            context "bump to alpha" do
+              it "bumps to patch version and resets prerelease" do
+                expect_downgrade_error { promote("1.2.3-beta.1", "patch", "alpha") }
+              end
+            end
+
+            context "bump to beta" do
+              it "bumps to patch version and resets prerelease" do
+                expect(promote("1.2.3-beta.1", "patch", "beta")).to eql("1.2.3-beta.2")
+                expect(promote("1.2.3-beta.2", "patch", "beta")).to eql("1.2.3-beta.3")
+              end
+            end
+
+            context "bump to rc" do
+              it "bumps to patch version and resets prerelease" do
+                expect(promote("1.2.3-beta.1", "patch", "rc")).to eql("1.2.3-rc.1")
+                expect(promote("1.2.3-beta.2", "patch", "rc")).to eql("1.2.3-rc.1")
+              end
+            end
+          end
+
+          context "with existing rc prerelease" do
+            context "bump to alpha" do
+              it "bumps to patch version and resets prerelease" do
+                expect_downgrade_error { promote("1.2.3-rc.1", "patch", "alpha") }
+              end
+            end
+
+            context "bump to beta" do
+              it "bumps to patch version and resets prerelease" do
+                expect_downgrade_error { promote("1.2.3-rc.1", "patch", "beta") }
+              end
+            end
+
+            context "bump to rc" do
+              it "bumps to patch version and resets prerelease" do
+                expect(promote("1.2.3-rc.1", "patch", "rc")).to eql("1.2.3-rc.2")
+                expect(promote("1.2.3-rc.2", "patch", "rc")).to eql("1.2.3-rc.3")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def expect_downgrade_error(&block)
+    expect(&block).to raise_error(Mono::VersionPromoter::UnsupportedDowngradeError)
+  end
+end

--- a/spec/lib/mono/version_spec.rb
+++ b/spec/lib/mono/version_spec.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+RSpec.describe Mono::Version do
+  def parse(string)
+    described_class.parse(string)
+  end
+
+  def parse_ruby(string)
+    described_class.parse_ruby(string)
+  end
+
+  describe ".parse" do
+    context "with plain release" do
+      it "returns Version object" do
+        expect(parse("1.0.0")).to have_attributes(
+          :major => 1,
+          :minor => 0,
+          :patch => 0,
+          :prerelease_type => nil,
+          :prerelease_version => nil
+        )
+        expect(parse("1.2.3")).to have_attributes(
+          :major => 1,
+          :minor => 2,
+          :patch => 3,
+          :prerelease_type => nil,
+          :prerelease_version => nil
+        )
+      end
+    end
+
+    context "with prerelease using a dash (-)" do
+      it "returns Version object" do
+        expect(parse("1.0.0-alpha.1")).to have_attributes(
+          :major => 1,
+          :minor => 0,
+          :patch => 0,
+          :prerelease_type => "alpha",
+          :prerelease_version => 1
+        )
+        expect(parse("1.2.3-alpha.1")).to have_attributes(
+          :major => 1,
+          :minor => 2,
+          :patch => 3,
+          :prerelease_type => "alpha",
+          :prerelease_version => 1
+        )
+        expect(parse("1.2.3-beta.2")).to have_attributes(
+          :major => 1,
+          :minor => 2,
+          :patch => 3,
+          :prerelease_type => "beta",
+          :prerelease_version => 2
+        )
+        expect(parse("1.2.3-rc.3")).to have_attributes(
+          :major => 1,
+          :minor => 2,
+          :patch => 3,
+          :prerelease_type => "rc",
+          :prerelease_version => 3
+        )
+      end
+    end
+
+    context "with prerelease using a dot (.)" do
+      it "returns Version object" do
+        expect(parse_ruby("1.0.0.alpha.1")).to have_attributes(
+          :major => 1,
+          :minor => 0,
+          :patch => 0,
+          :prerelease_type => "alpha",
+          :prerelease_version => 1
+        )
+        expect(parse_ruby("1.2.3.alpha.1")).to have_attributes(
+          :major => 1,
+          :minor => 2,
+          :patch => 3,
+          :prerelease_type => "alpha",
+          :prerelease_version => 1
+        )
+        expect(parse_ruby("1.2.3.beta.2")).to have_attributes(
+          :major => 1,
+          :minor => 2,
+          :patch => 3,
+          :prerelease_type => "beta",
+          :prerelease_version => 2
+        )
+        expect(parse_ruby("1.2.3.rc.3")).to have_attributes(
+          :major => 1,
+          :minor => 2,
+          :patch => 3,
+          :prerelease_type => "rc",
+          :prerelease_version => 3
+        )
+      end
+    end
+  end
+
+  describe "#to_s" do
+    context "with plain release" do
+      it "returns version string" do
+        expect(parse("1.0.0").to_s).to eql("1.0.0")
+        expect(parse("1.2.3").to_s).to eql("1.2.3")
+      end
+    end
+
+    context "with prerelease using a dash (-)" do
+      it "returns version string" do
+        expect(parse("1.0.0-alpha.1").to_s).to eql("1.0.0-alpha.1")
+        expect(parse("1.2.3-alpha.10").to_s).to eql("1.2.3-alpha.10")
+        expect(parse("11.12.13-beta.20").to_s).to eql("11.12.13-beta.20")
+        expect(parse("201.202.203-rc.999").to_s).to eql("201.202.203-rc.999")
+      end
+    end
+
+    context "with prerelease using a dot (.)" do
+      it "returns Version string" do
+        expect(parse_ruby("1.0.0.alpha.1").to_s).to eql("1.0.0.alpha.1")
+        expect(parse_ruby("1.2.3.alpha.10").to_s).to eql("1.2.3.alpha.10")
+        expect(parse_ruby("11.12.13.beta.20").to_s).to eql("11.12.13.beta.20")
+        expect(parse_ruby("201.202.203.rc.999").to_s).to eql("201.202.203.rc.999")
+      end
+    end
+  end
+
+  describe "#prerelease_bump" do
+    context "with major prerelease" do
+      it "returns major" do
+        expect(parse("1.0.0-alpha.2").prerelease_bump).to eql(:major)
+        expect(parse_ruby("3.0.0.alpha.4").prerelease_bump).to eql(:major)
+      end
+    end
+
+    context "with minor prerelease" do
+      it "returns minor" do
+        expect(parse("1.2.0-alpha.3").prerelease_bump).to eql(:minor)
+        expect(parse_ruby("3.4.0.alpha.5").prerelease_bump).to eql(:minor)
+      end
+    end
+
+    context "with patch prerelease" do
+      it "returns patch" do
+        expect(parse("1.2.3-alpha.4").prerelease_bump).to eql(:patch)
+        expect(parse_ruby("5.6.7.alpha.8").prerelease_bump).to eql(:patch)
+      end
+    end
+
+    context "without prerelease" do
+      it "returns nil" do
+        expect(parse("1.2.3").prerelease_bump).to be_nil
+      end
+    end
+  end
+
+  describe "#prerelease?" do
+    context "with prerelease" do
+      context "using a dash (-)" do
+        it "returns true" do
+          expect(parse("1.2.3-alpha.1").prerelease?).to be_truthy
+          expect(parse("1.2.3-beta.2").prerelease?).to be_truthy
+          expect(parse("1.2.3-rc.3").prerelease?).to be_truthy
+        end
+      end
+
+      context "using a dot (.)" do
+        it "returns true" do
+          expect(parse_ruby("1.2.3.alpha.1").prerelease?).to be_truthy
+          expect(parse_ruby("1.2.3.beta.2").prerelease?).to be_truthy
+          expect(parse_ruby("1.2.3.rc.3").prerelease?).to be_truthy
+        end
+      end
+    end
+
+    context "without prerelease" do
+      it "returns false" do
+        expect(parse("1.2.3").prerelease?).to be_falsy
+      end
+    end
+  end
+
+  describe "#prerelease_bump" do
+    context "with major prerelease" do
+      it "returns major" do
+        expect(parse("1.0.0-alpha.2").prerelease_bump).to eql(:major)
+        expect(parse_ruby("3.0.0.alpha.4").prerelease_bump).to eql(:major)
+      end
+    end
+
+    context "with minor prerelease" do
+      it "returns minor" do
+        expect(parse("1.2.0-alpha.3").prerelease_bump).to eql(:minor)
+        expect(parse_ruby("3.4.0.alpha.5").prerelease_bump).to eql(:minor)
+      end
+    end
+
+    context "with patch prerelease" do
+      it "returns patch" do
+        expect(parse("1.2.3-alpha.4").prerelease_bump).to eql(:patch)
+        expect(parse_ruby("5.6.7.alpha.8").prerelease_bump).to eql(:patch)
+      end
+    end
+
+    context "without prerelease" do
+      it "returns nil" do
+        expect(parse("1.2.3").prerelease_bump).to be_nil
+      end
+    end
+  end
+end

--- a/spec/lib/mono/version_spec.rb
+++ b/spec/lib/mono/version_spec.rb
@@ -123,31 +123,29 @@ RSpec.describe Mono::Version do
     end
   end
 
-  describe "#prerelease_bump" do
-    context "with major prerelease" do
-      it "returns major" do
-        expect(parse("1.0.0-alpha.2").prerelease_bump).to eql(:major)
-        expect(parse_ruby("3.0.0.alpha.4").prerelease_bump).to eql(:major)
+  describe "#segments" do
+    context "with plain release" do
+      it "returns version string" do
+        expect(parse("1.0.0").segments).to eql([1, 0, 0])
+        expect(parse("1.2.3").segments).to eql([1, 2, 3])
       end
     end
 
-    context "with minor prerelease" do
-      it "returns minor" do
-        expect(parse("1.2.0-alpha.3").prerelease_bump).to eql(:minor)
-        expect(parse_ruby("3.4.0.alpha.5").prerelease_bump).to eql(:minor)
+    context "with prerelease using a dash (-)" do
+      it "returns version string" do
+        expect(parse("1.0.0-alpha.1").segments).to eql([1, 0, 0, "alpha", 1])
+        expect(parse("1.2.3-alpha.10").segments).to eql([1, 2, 3, "alpha", 10])
+        expect(parse("11.12.13-beta.20").segments).to eql([11, 12, 13, "beta", 20])
+        expect(parse("201.202.203-rc.999").segments).to eql([201, 202, 203, "rc", 999])
       end
     end
 
-    context "with patch prerelease" do
-      it "returns patch" do
-        expect(parse("1.2.3-alpha.4").prerelease_bump).to eql(:patch)
-        expect(parse_ruby("5.6.7.alpha.8").prerelease_bump).to eql(:patch)
-      end
-    end
-
-    context "without prerelease" do
-      it "returns nil" do
-        expect(parse("1.2.3").prerelease_bump).to be_nil
+    context "with prerelease using a dot (.)" do
+      it "returns Version string" do
+        expect(parse_ruby("1.0.0.alpha.1").segments).to eql([1, 0, 0, "alpha", 1])
+        expect(parse_ruby("1.2.3.alpha.10").segments).to eql([1, 2, 3, "alpha", 10])
+        expect(parse_ruby("11.12.13.beta.20").segments).to eql([11, 12, 13, "beta", 20])
+        expect(parse_ruby("201.202.203.rc.999").segments).to eql([201, 202, 203, "rc", 999])
       end
     end
   end


### PR DESCRIPTION
[skip review]

## Extract version number logic to its own class

Wrap around the `Gem::Version` class from Ruby and handle the different
separators between base version (1.2.3) and prereleases (alpha.1). Ruby
gems use a dot (.) and other language projects use a dash (-).

I considered implementing my own Ruby version parser, but this
workaround (of using `sub` to replace a dash with a dot) to make it work
with other programming languages works well enough for now.

## Add VersionPromoter to bump version numbers

Add class to help promote/bump version numbers. Extract this from the
Package class so that it can be used (and tested) separately.

I added a lot of tests. This makes sure all scenarios are covered, all
the different version bumps and all the different scenarios that arise
with prerelease versions.

It did not implement support for prerelease downgrades: It's not
possible to go from 1.0.0-beta.1 to 1.0.0-alpha.2. For this I would need
to add parsing for existing git tags to see what the latest release for
the downgraded prerelease type is and that's too much work right now. I
also don't know if there's a situation where you would want to downgrade
the prerelease that's not just another prerelease version of the same
type.

