### PR TITLE
Add unbootstrap command, redesign clean command

### DIFF
--- a/.changesets/unbootstrap-command.md
+++ b/.changesets/unbootstrap-command.md
@@ -1,0 +1,8 @@
+---
+bump: "minor"
+---
+
+Add the unbootstrap command. This command will be the same behavior as the
+previous "clean" command. The clean command will instead be the opposite of the
+"build" command, cleaning up after the build command, removing any build
+artifacts.

--- a/README.md
+++ b/README.md
@@ -241,11 +241,31 @@ Examples of releases:
 
 ### Clean
 
-Clean the project to a state before the initial bootstrap. This command removes
-all dependencies and deletes temporary directories.
+Clean the project to before the [build](#build) step.
 
 ```
 mono clean
+```
+
+- Ruby:
+    - Removes `*.gem` files specified in the `gem_files_dir`.
+- Elixir:
+    - Removes the build artifacts in `_build`.
+- Node.js
+    - Runs the `clean` script configured for the package's `package.json`.
+
+Clean the project package(s) to a before [build](#build) state.
+
+### Unbootstrap
+
+Resets the project to a state before the initial bootstrap. This command
+removes all dependencies and deletes temporary directories.
+
+Run the [clean](#clean) command before this command if you also want to undo
+the [build](#build) step.
+
+```
+mono unbootstrap
 ```
 
 - Ruby:

--- a/lib/mono/cli.rb
+++ b/lib/mono/cli.rb
@@ -151,6 +151,8 @@ module Mono
           Mono::Cli::Init.new.execute
         when "bootstrap"
           Mono::Cli::Bootstrap.new(bootstrap_options).execute
+        when "unbootstrap"
+          Mono::Cli::Unbootstrap.new(unbootstrap_options).execute
         when "clean"
           Mono::Cli::Clean.new(clean_options).execute
         when "build"
@@ -197,6 +199,7 @@ module Mono
       AVAILABLE_COMMANDS = %w[
         init
         bootstrap
+        unbootstrap
         clean
         build
         test
@@ -237,6 +240,14 @@ module Mono
             "Bootstrap the project optimized for CI environments" do |value|
             params[:ci] = value
           end
+        end.parse(@options)
+        params
+      end
+
+      def unbootstrap_options
+        params = {}
+        OptionParser.new do |opts|
+          opts.banner = "Usage: mono unbootstrap [options]"
         end.parse(@options)
         params
       end

--- a/lib/mono/cli/unbootstrap.rb
+++ b/lib/mono/cli/unbootstrap.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Mono
+  module Cli
+    class Unbootstrap < Base
+      def execute
+        puts "Unbootstrapping project"
+        run_hooks("unbootstrap", "pre")
+        language.unbootstrap
+        packages.each do |package|
+          puts "# Unbootstrapping package: #{package.name} (#{package.path})"
+          package.unbootstrap
+        end
+        run_hooks("unbootstrap", "post")
+      end
+    end
+  end
+end

--- a/lib/mono/languages/elixir/language.rb
+++ b/lib/mono/languages/elixir/language.rb
@@ -8,6 +8,10 @@ module Mono
           # noop
         end
 
+        def unbootstrap(_options = {})
+          # noop
+        end
+
         def clean(_options = {})
           # noop
         end

--- a/lib/mono/languages/elixir/package.rb
+++ b/lib/mono/languages/elixir/package.rb
@@ -39,6 +39,10 @@ module Mono
         end
 
         def clean_package
+          run_command_in_package "rm -rf _build"
+        end
+
+        def unbootstrap_package
           run_command_in_package "mix deps.clean --all && mix clean"
         end
 

--- a/lib/mono/languages/nodejs/language.rb
+++ b/lib/mono/languages/nodejs/language.rb
@@ -42,6 +42,10 @@ module Mono
         end
 
         def clean(_options = {})
+          # noop
+        end
+
+        def unbootstrap(_options = {})
           run_command "rm -rf node_modules"
         end
 

--- a/lib/mono/languages/nodejs/package.rb
+++ b/lib/mono/languages/nodejs/package.rb
@@ -53,6 +53,12 @@ module Mono
         end
 
         def clean_package
+          check_if_command_exists!("clean")
+
+          run_client_command_for_package "run clean"
+        end
+
+        def unbootstrap_package
           run_command_in_package "rm -rf node_modules"
         end
 

--- a/lib/mono/languages/ruby/language.rb
+++ b/lib/mono/languages/ruby/language.rb
@@ -8,6 +8,10 @@ module Mono
           # noop
         end
 
+        def unbootstrap(_options = {})
+          # noop
+        end
+
         def clean(_options = {})
           # noop
         end

--- a/lib/mono/languages/ruby/package.rb
+++ b/lib/mono/languages/ruby/package.rb
@@ -46,6 +46,18 @@ module Mono
         end
 
         def clean_package
+          paths = []
+          files_dir = gem_files_dir
+          paths << path
+          paths << files_dir if files_dir
+          paths << "*.gem"
+          gem_files = Dir.glob(File.join(paths))
+          gem_files.each do |gem_file|
+            FileUtils.remove gem_file
+          end
+        end
+
+        def unbootstrap_package
           run_command_in_package "rm -rf vendor/ tmp/"
         end
 
@@ -62,22 +74,26 @@ module Mono
           File.join(path, version_file)
         end
 
-        def fetch_gem_files_paths
+        def gem_files_dir
           gem_files_dir = config.publish["gem_files_dir"]
-          dir = gem_files_dir if gem_files_dir && !gem_files_dir.empty?
+          gem_files_dir if gem_files_dir && !gem_files_dir.strip.empty?
+        end
+
+        def fetch_gem_files_paths
+          files_dir = gem_files_dir
 
           # Normal .gem files
           # Example: package-1.2.3.gem
           paths = []
           base_path = []
-          base_path << dir if dir
+          base_path << files_dir if files_dir
           base_path << "*-#{next_version}.gem"
           paths << File.join(base_path)
 
           # Platform .gem files
           # Example: package-1.2.3-java.gem
           platform_path = []
-          platform_path << dir if dir
+          platform_path << files_dir if files_dir
           platform_path << "*-#{next_version}-*.gem"
           paths << File.join(platform_path)
 

--- a/lib/mono/package.rb
+++ b/lib/mono/package.rb
@@ -123,6 +123,15 @@ module Mono
       end
     end
 
+    def unbootstrap
+      if config.command?("unbootstrap")
+        # Custom command configured
+        run_command_in_package config.command("unbootstrap")
+      else
+        unbootstrap_package
+      end
+    end
+
     def run_custom_command(command)
       run_command_in_package command
     end
@@ -145,6 +154,10 @@ module Mono
     end
 
     def clean_package
+      raise NotImplementedError
+    end
+
+    def unbootstrap_package
       raise NotImplementedError
     end
     # :nocov:

--- a/spec/lib/mono/cli/unbootstrap_spec.rb
+++ b/spec/lib/mono/cli/unbootstrap_spec.rb
@@ -1,0 +1,291 @@
+# frozen_string_literal: true
+
+RSpec.describe Mono::Cli::Unbootstrap do
+  context "with custom command" do
+    context "with single package" do
+      it "runs custom command" do
+        prepare_project :elixir_single
+        output =
+          capture_stdout do
+            in_project do
+              configure_command("unbootstrap", "echo unbootstrap")
+              run_unbootstrap
+            end
+          end
+
+        expect(output).to include("Unbootstrapping package: elixir_single_project (.)")
+        expect(performed_commands).to eql([
+          ["/elixir_single_project", "echo unbootstrap"]
+        ])
+        expect(exit_status).to eql(0), output
+      end
+    end
+
+    context "with mono repo" do
+      it "runs custom command" do
+        prepare_project :elixir_mono
+        output =
+          capture_stdout do
+            in_project do
+              configure_command("unbootstrap", "echo unbootstrap")
+              run_unbootstrap
+            end
+          end
+
+        project_path = "/elixir_mono_project"
+        package_one_path = "#{project_path}/packages/package_one"
+        package_two_path = "#{project_path}/packages/package_two"
+        expect(output).to include("Unbootstrapping package: package_one (packages/package_one)")
+        expect(output).to include("Unbootstrapping package: package_two (packages/package_two)")
+        expect(performed_commands).to eql([
+          [package_one_path, "echo unbootstrap"],
+          [package_two_path, "echo unbootstrap"]
+        ])
+        expect(exit_status).to eql(0), output
+      end
+    end
+  end
+
+  context "with Elixir project" do
+    context "with single repo" do
+      it "unbootstraps the project" do
+        prepare_project :elixir_single
+        output =
+          capture_stdout do
+            in_project { run_unbootstrap }
+          end
+
+        expect(output).to include("Unbootstrapping package: elixir_single_project (.)")
+        expect(performed_commands).to eql([
+          ["/elixir_single_project", "mix deps.clean --all && mix clean"]
+        ])
+        expect(exit_status).to eql(0), output
+      end
+
+      context "with hooks" do
+        it "runs hooks around command" do
+          prepare_project :elixir_single
+          output =
+            capture_stdout do
+              in_project do
+                add_hook("unbootstrap", "pre", "echo before")
+                add_hook("unbootstrap", "post", "echo after")
+                run_unbootstrap
+              end
+            end
+
+          expect(output).to include("Unbootstrapping package: elixir_single_project (.)")
+          expect(performed_commands).to eql([
+            ["/elixir_single_project", "echo before"],
+            ["/elixir_single_project", "mix deps.clean --all && mix clean"],
+            ["/elixir_single_project", "echo after"]
+          ])
+          expect(exit_status).to eql(0), output
+        end
+      end
+    end
+
+    context "with mono repo" do
+      it "unbootstraps the packages" do
+        prepare_project :elixir_mono
+        output =
+          capture_stdout do
+            in_project { run_unbootstrap }
+          end
+
+        expect(output).to include("Unbootstrapping package: package_one (packages/package_one)")
+        expect(output).to include("Unbootstrapping package: package_two (packages/package_two)")
+        expect(performed_commands).to eql([
+          ["/elixir_mono_project/packages/package_one", "mix deps.clean --all && mix clean"],
+          ["/elixir_mono_project/packages/package_two", "mix deps.clean --all && mix clean"]
+        ])
+        expect(exit_status).to eql(0), output
+      end
+
+      context "with hooks" do
+        it "runs hooks around command" do
+          prepare_project :elixir_mono
+          output =
+            capture_stdout do
+              in_project do
+                add_hook("unbootstrap", "pre", "echo before")
+                add_hook("unbootstrap", "post", "echo after")
+                run_unbootstrap
+              end
+            end
+
+          project_path = "/elixir_mono_project"
+          package_one_path = "#{project_path}/packages/package_one"
+          package_two_path = "#{project_path}/packages/package_two"
+          expect(output).to include(
+            "Unbootstrapping package: package_one (packages/package_one)",
+            "Unbootstrapping package: package_two (packages/package_two)"
+          )
+          expect(performed_commands).to eql([
+            [project_path, "echo before"],
+            [package_one_path, "mix deps.clean --all && mix clean"],
+            [package_two_path, "mix deps.clean --all && mix clean"],
+            [project_path, "echo after"]
+          ])
+          expect(exit_status).to eql(0), output
+        end
+      end
+    end
+  end
+
+  context "with Ruby project" do
+    context "with single repo" do
+      it "unbootstraps the project" do
+        prepare_project :ruby_single
+        output =
+          capture_stdout do
+            in_project { run_unbootstrap }
+          end
+
+        expect(output).to include("Unbootstrapping package: ruby_single_project (.)")
+        expect(performed_commands).to eql([
+          ["/ruby_single_project", "rm -rf vendor/ tmp/"]
+        ])
+        expect(exit_status).to eql(0), output
+      end
+    end
+
+    context "with mono repo" do
+      it "unbootstraps the packages" do
+        prepare_project :ruby_mono
+        output =
+          capture_stdout do
+            in_project { run_unbootstrap }
+          end
+
+        expect(output).to include("Unbootstrapping package: package_one (packages/package_one)")
+        expect(output).to include("Unbootstrapping package: package_two (packages/package_two)")
+        expect(performed_commands).to eql([
+          ["/ruby_mono_project/packages/package_one", "rm -rf vendor/ tmp/"],
+          ["/ruby_mono_project/packages/package_two", "rm -rf vendor/ tmp/"]
+        ])
+        expect(exit_status).to eql(0), output
+      end
+    end
+  end
+
+  context "with Node.js project" do
+    context "with npm" do
+      context "with single repo" do
+        it "unbootstraps the project" do
+          prepare_project :nodejs_npm_single
+          output =
+            capture_stdout do
+              in_project { run_unbootstrap }
+            end
+
+          expect(output).to include("Unbootstrapping package: nodejs_npm_single_project (.)")
+          expect(performed_commands).to eql([
+            ["/nodejs_npm_single_project", "rm -rf node_modules"],
+            ["/nodejs_npm_single_project", "rm -rf node_modules"]
+          ])
+          expect(exit_status).to eql(0), output
+        end
+      end
+
+      context "with mono repo" do
+        it "unbootstraps the project workspace" do
+          prepare_project :nodejs_npm_mono
+          output =
+            capture_stdout do
+              in_project { run_unbootstrap }
+            end
+
+          project_path = "/nodejs_npm_mono_project"
+          package_one_path = "#{project_path}/packages/package_one"
+          package_two_path = "#{project_path}/packages/package_two"
+          expect(output).to include(
+            "Unbootstrapping package: package_one (packages/package_one)",
+            "Unbootstrapping package: package_two (packages/package_two)"
+          )
+          expect(performed_commands).to eql([
+            [project_path, "rm -rf node_modules"],
+            [package_one_path, "rm -rf node_modules"],
+            [package_two_path, "rm -rf node_modules"]
+          ])
+          expect(exit_status).to eql(0), output
+        end
+      end
+    end
+
+    context "with yarn" do
+      context "with single repo" do
+        it "unbootstraps the project" do
+          prepare_project :nodejs_yarn_single
+          output =
+            capture_stdout do
+              in_project { run_unbootstrap }
+            end
+
+          expect(output).to include("Unbootstrapping package: nodejs_yarn_single_project (.)")
+          expect(performed_commands).to eql([
+            ["/nodejs_yarn_single_project", "rm -rf node_modules"],
+            ["/nodejs_yarn_single_project", "rm -rf node_modules"]
+          ])
+          expect(exit_status).to eql(0), output
+        end
+      end
+
+      context "with mono repo" do
+        it "unbootstraps the project workspace" do
+          prepare_project :nodejs_yarn_mono
+          output =
+            capture_stdout do
+              in_project { run_unbootstrap }
+            end
+
+          project_path = "/nodejs_yarn_mono_project"
+          package_one_path = "#{project_path}/packages/package_one"
+          package_two_path = "#{project_path}/packages/package_two"
+          expect(output).to include(
+            "Unbootstrapping package: package_one (packages/package_one)",
+            "Unbootstrapping package: package_two (packages/package_two)"
+          )
+          expect(performed_commands).to eql([
+            [project_path, "rm -rf node_modules"],
+            [package_one_path, "rm -rf node_modules"],
+            [package_two_path, "rm -rf node_modules"]
+          ])
+          expect(exit_status).to eql(0), output
+        end
+      end
+    end
+  end
+
+  context "with unknown language project" do
+    context "with single repo" do
+      it "prints an error and exits" do
+        prepare_project :unknown_single
+        output =
+          capture_stdout do
+            in_project { run_unbootstrap }
+          end
+
+        expect(output).to include("UnknownLanguageError: Unknown language configured"), output
+        expect(exit_status).to eql(1), output
+      end
+    end
+
+    context "with mono repo" do
+      it "unbootstraps the packages" do
+        prepare_project :unknown_mono
+        output =
+          capture_stdout do
+            in_project { run_unbootstrap }
+          end
+
+        expect(output).to include("UnknownLanguageError: Unknown language configured"), output
+        expect(exit_status).to eql(1), output
+      end
+    end
+  end
+
+  def run_unbootstrap(args = [])
+    Mono::Cli::Wrapper.new(["unbootstrap"] + args).execute
+  end
+end

--- a/spec/support/examples/nodejs_npm_mono_project/packages/package_one/package.json
+++ b/spec/support/examples/nodejs_npm_mono_project/packages/package_one/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "prebuild": "echo 123 > constants.js",
     "build": "echo 123",
-    "test": "echo run test"
+    "test": "echo run test",
+    "clean": "echo run clean"
   }
 }

--- a/spec/support/examples/nodejs_npm_mono_project/packages/package_two/package.json
+++ b/spec/support/examples/nodejs_npm_mono_project/packages/package_two/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "build": "echo 123",
-    "test": "echo run test"
+    "test": "echo run test",
+    "clean": "echo run clean"
   }
 }

--- a/spec/support/examples/nodejs_npm_single_project/package.json
+++ b/spec/support/examples/nodejs_npm_single_project/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "prebuild": "echo 123 > constants.js",
     "build": "echo 123",
-    "test": "echo run test"
+    "test": "echo run test",
+    "clean": "echo run clean"
   }
 }

--- a/spec/support/examples/nodejs_yarn_mono_project/packages/package_one/package.json
+++ b/spec/support/examples/nodejs_yarn_mono_project/packages/package_one/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "prebuild": "echo 123 > constants.js",
     "build": "echo 123",
-    "test": "echo run test"
+    "test": "echo run test",
+    "clean": "echo run clean"
   }
 }

--- a/spec/support/examples/nodejs_yarn_mono_project/packages/package_two/package.json
+++ b/spec/support/examples/nodejs_yarn_mono_project/packages/package_two/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "prebuild": "echo 123 > constants.js",
     "build": "echo 123",
-    "test": "echo run test"
+    "test": "echo run test",
+    "clean": "echo run clean"
   }
 }

--- a/spec/support/examples/nodejs_yarn_single_project/package.json
+++ b/spec/support/examples/nodejs_yarn_single_project/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "prebuild": "echo 123 > constants.js",
     "build": "echo 123",
-    "test": "echo run test"
+    "test": "echo run test",
+    "clean": "echo run clean"
   }
 }


### PR DESCRIPTION
The "unbootstrap" command will have the same behavior as the "clean"
command did previously.

The "clean" command now will be focussed on cleaning the project back to
the state before the "build" command. For Ruby this means removing the
`*.gem` files. For Elixir this means removing the `_build` directory.
And for Node.js this means running the `clean` script configured in
`package.json`.

This split in behavior allows us to be more specific in what actions we
want to perform. We usually don't want to unbootstrap a project, but
clean it instead, so we can run another fresh build.

[skip review]