### PR TITLE
Add support for Node.js prerelease tags

### DIFF
--- a/.changesets/node-js-prerelease-tags.md
+++ b/.changesets/node-js-prerelease-tags.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Add support for Node.js prerelease tags. When a prerelease is published, it will automatically tag the release on npmjs.org with the matching prerelease tag. For example: `mono publish --alpha` creates the "alpha" tag.

--- a/lib/mono/languages/nodejs/package.rb
+++ b/lib/mono/languages/nodejs/package.rb
@@ -52,7 +52,9 @@ module Mono
         end
 
         def publish_package
-          options = " --tag beta" if next_version.prerelease?
+          if next_version.prerelease?
+            options = " --tag #{next_version.prerelease_type}"
+          end
           run_client_command_for_package "publish#{options}"
         end
 


### PR DESCRIPTION
When a new release is published in npm, you can add a tag. These tags
are used for release branches or alpha/beta/rc releases. This change
automatically uses the correct tag for a prerelease. This also prevents
that prereleases are tagged as "latest", which means they're installed
automatically.

[skip review]