### PR TITLE
Fix version promotion from prereleases

### DIFF
--- a/.changesets/fix-base-release-after-prerelease.md
+++ b/.changesets/fix-base-release-after-prerelease.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Fix base release after prerelease. The `mono publish` command would fail if the package version was a prerelease, updating to a base/final release.

--- a/lib/mono/version_promoter.rb
+++ b/lib/mono/version_promoter.rb
@@ -135,6 +135,9 @@ module Mono
       return true unless current_index
 
       new_index = PRERELEASE_VERSIONS.index(new)
+      # New release is not a prerelease, so it can be updated
+      return true unless new_index
+
       # Test against reverse order of array values
       new_index <= current_index
     end

--- a/spec/lib/mono/cli/publish/base_spec.rb
+++ b/spec/lib/mono/cli/publish/base_spec.rb
@@ -230,6 +230,69 @@ RSpec.describe Mono::Cli::Publish do
     end
   end
 
+  context "with prerelease" do
+    it "publishes a final release" do
+      prepare_new_project do
+        create_mono_config "language" => "ruby"
+        create_ruby_package_files :name => "package_a", :version => "1.2.3.alpha.1"
+        add_changeset :patch
+      end
+      confirm_publish_package
+      output =
+        capture_stdout do
+          in_project do
+            perform_commands do
+              stub_commands [/^gem push/, /^git push/] do
+                run_publish
+              end
+            end
+          end
+        end
+
+      project_dir = "/#{current_project}"
+      next_version = "1.2.3"
+
+      expect(output).to include(<<~OUTPUT), output
+        The following packages will be published (or not):
+        - #{current_project}:
+          Current version: v1.2.3.alpha.1
+          Next version:    v1.2.3 (patch)
+      OUTPUT
+      expect(output).to include(<<~OUTPUT), output
+        # Updating package versions
+        - #{current_project}:
+          Current version: v1.2.3.alpha.1
+          Next version:    v1.2.3 (patch)
+      OUTPUT
+
+      in_project do
+        expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version}"))
+        expect(current_package_changeset_files.length).to eql(0)
+
+        changelog = File.read("CHANGELOG.md")
+        expect_changelog_to_include_version_header(changelog, next_version)
+        expect_changelog_to_include_release_notes(changelog, :patch)
+
+        expect(local_changes?).to be_falsy, local_changes.inspect
+        expect(commited_files).to eql([
+          ".changesets/1_patch.md",
+          "CHANGELOG.md",
+          "lib/example/version.rb"
+        ])
+      end
+
+      expect(performed_commands).to eql([
+        [project_dir, "gem build"],
+        [project_dir, "git add -A"],
+        [project_dir, "git commit -m 'Publish packages [ci skip]' -m '- v#{next_version}'"],
+        [project_dir, "git tag v#{next_version}"],
+        [project_dir, "gem push package_a-#{next_version}.gem"],
+        [project_dir, "git push origin main v#{next_version}"]
+      ])
+      expect(exit_status).to eql(0), output
+    end
+  end
+
   context "with hooks" do
     it "runs hooks around command" do
       prepare_project :ruby_single

--- a/spec/lib/mono/version_promoter_spec.rb
+++ b/spec/lib/mono/version_promoter_spec.rb
@@ -8,26 +8,54 @@ RSpec.describe Mono::VersionPromoter do
 
   describe ".promote" do
     context "when promoting to a base release" do
-      context "when promoting to a major release" do
-        it "bumps to a new major version" do
-          expect(promote("1.2.3", "major")).to eql("2.0.0")
-          expect(promote("1.2.0", "major")).to eql("2.0.0")
-          expect(promote("1.0.0", "major")).to eql("2.0.0")
+      context "when promoting a base release" do
+        context "when promoting to a major release" do
+          it "bumps to a new major version" do
+            expect(promote("1.2.3", "major")).to eql("2.0.0")
+            expect(promote("1.2.0", "major")).to eql("2.0.0")
+            expect(promote("1.0.0", "major")).to eql("2.0.0")
+          end
+        end
+
+        context "when promoting to a minor release" do
+          it "bumps to a new minor version" do
+            expect(promote("1.2.3", "minor")).to eql("1.3.0")
+            expect(promote("1.2.0", "minor")).to eql("1.3.0")
+            expect(promote("1.0.0", "minor")).to eql("1.1.0")
+          end
+        end
+
+        context "when promoting to a patch release" do
+          it "bumps to a new patch version" do
+            expect(promote("1.2.3", "patch")).to eql("1.2.4")
+            expect(promote("1.2.4", "patch")).to eql("1.2.5")
+          end
         end
       end
 
-      context "when promoting to a minor release" do
-        it "bumps to a new minor version" do
-          expect(promote("1.2.3", "minor")).to eql("1.3.0")
-          expect(promote("1.2.0", "minor")).to eql("1.3.0")
-          expect(promote("1.0.0", "minor")).to eql("1.1.0")
+      context "when promoting a prerelease" do
+        context "when promoting to a major release" do
+          it "bumps to a new major version" do
+            expect(promote("1.2.3-alpha.1", "major")).to eql("2.0.0")
+            expect(promote("1.2.0-beta.2", "major")).to eql("2.0.0")
+            expect(promote("1.0.0-rc.3", "major")).to eql("1.0.0")
+          end
         end
-      end
 
-      context "when promoting to a patch release" do
-        it "bumps to a new patch version" do
-          expect(promote("1.2.3", "patch")).to eql("1.2.4")
-          expect(promote("1.2.4", "patch")).to eql("1.2.5")
+        context "when promoting to a minor release" do
+          it "bumps to a new minor version" do
+            expect(promote("1.2.3-alpha.1", "minor")).to eql("1.3.0")
+            expect(promote("1.2.0-beta.2", "minor")).to eql("1.2.0")
+            expect(promote("1.0.0-rc.3", "minor")).to eql("1.0.0")
+          end
+        end
+
+        context "when promoting to a patch release" do
+          it "bumps to a new patch version" do
+            expect(promote("1.2.3-alpha.1", "patch")).to eql("1.2.3")
+            expect(promote("1.2.0-beta.2", "patch")).to eql("1.2.0")
+            expect(promote("1.0.0-rc.3", "patch")).to eql("1.0.0")
+          end
         end
       end
     end


### PR DESCRIPTION
The VersionPromoter didn't support promoting versions that were a
prerelease to a base release.

What would happens is:
- If a library has version 1.2.3-alpha.1
- When `mono publish` is run (without a prerelease option)
- The command would error.

The problem was caused by the check if prerelease are larger than one
another, so that you can't release an alpha version when the current
version is a beta version.

This change skips the check, if the new prerelease is not present (and
the new version is base/final release).

This fix allows us to publish versions final releases after the
prerelease track.

[skip review]