### PR TITLE
Remove the tag prefix logic

### DIFF
--- a/.changesets/remove-tag_prefix-config-option.md
+++ b/.changesets/remove-tag_prefix-config-option.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Remove tag_prefix config option. It is no longer necessary for Node.js packages. We already read the package name from the `package.json` file, where the package name includes the prefix already.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ it later.
 language: nodejs
 repo: "https://github.com/appsignal/appsignal-javascript"
 npm_client: "yarn"
-tag_prefix: "@appsignal/"
 packages_dir: "packages"
 clean:
   command: "npm run clean"
@@ -72,12 +71,6 @@ test:
 - `repo`
     - Repository used to link back to from the `CHANGELOG` file.
     - Must be a valid URL.
-- `tag_prefix`
-    - Git tag prefix used to namespace tags.
-    - Example value `@appsignal/` creates the tag `@appsignal/<package>@1.2.3`
-- `tag_prefix`
-    - Git tag prefix used to namespace tags.
-    - Example value `@appsignal/` creates the tag `@appsignal/<package>@1.2.3`
 - `packages_dir`
     - Specify the path, from the root of the project, to the directory in which
       the mono project packages can be found. If this config option is

--- a/lib/mono/cli/init.rb
+++ b/lib/mono/cli/init.rb
@@ -25,7 +25,6 @@ module Mono
         else
           puts "Configuring for mono package repo."
           config["packages_dir"] = packages_dir
-          config["tag_prefix"] = ""
         end
         puts "Writing config file."
         File.open(File.join(Dir.pwd, "mono.yml"), "w+") do |file|

--- a/lib/mono/package.rb
+++ b/lib/mono/package.rb
@@ -73,28 +73,12 @@ module Mono
       @changesets ||= ChangesetCollection.new(config, self)
     end
 
-    def tag_prefix
-      return unless @config.config?("tag_prefix")
-
-      @config.config("tag_prefix")
-    end
-
     def current_tag
-      version = current_version
-      if config.monorepo?
-        "#{tag_prefix}#{name}@#{version}"
-      else # Single repo
-        "v#{version}"
-      end
+      build_tag current_version
     end
 
     def next_tag
-      version = next_version
-      if config.monorepo?
-        "#{tag_prefix}#{name}@#{version}"
-      else # Single repo
-        "v#{version}"
-      end
+      build_tag next_version
     end
 
     def current_version
@@ -191,6 +175,14 @@ module Mono
 
     def run_command_in_package(command)
       run_command command, :dir => path
+    end
+
+    def build_tag(version)
+      if config.monorepo?
+        "#{name}@#{version}"
+      else # Single repo
+        "v#{version}"
+      end
     end
   end
 end

--- a/spec/lib/mono/cli/init_spec.rb
+++ b/spec/lib/mono/cli/init_spec.rb
@@ -42,8 +42,7 @@ RSpec.describe Mono::Cli::Init do
         config = YAML.safe_load(File.read("mono.yml"))
         expect(config).to eql(
           "language" => "elixir",
-          "packages_dir" => "packages",
-          "tag_prefix" => ""
+          "packages_dir" => "packages"
         )
       end
       expect(performed_commands).to eql([])


### PR DESCRIPTION
This was initially added to add the tag prefix to the git tags, but
since we now read the package name from the Node.js package.json file,
the prefix is already present, also in the git tags.

No other languages need it currently, so remove it entirely.

[skip review]