### PR TITLE
Non module attribute elixir project versions

### DIFF
--- a/.changesets/handle-non-module-attribute-versions-in-elixir-projects.md
+++ b/.changesets/handle-non-module-attribute-versions-in-elixir-projects.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Aside from working on Elixir projects with their version set in a module attribute (`@version "1.2.3"` and `version: @version`), add support for projects with their versions set directly in the `project` block (`version: "1.2.3"`).

--- a/lib/mono/languages/elixir/package.rb
+++ b/lib/mono/languages/elixir/package.rb
@@ -9,7 +9,7 @@ module Mono
             begin
               contents = read_mix_exs
               matches = VERSION_REGEX.match(contents)
-              Version.parse(matches[1])
+              Version.parse(matches[2])
             end
         end
 
@@ -28,7 +28,7 @@ module Mono
         def update_spec
           contents = read_mix_exs
           new_contents =
-            contents.sub(VERSION_REGEX, %(@version "#{next_version}"))
+            contents.sub(VERSION_REGEX, "\\1 \"#{next_version}\"\\3")
           File.open(mix_exs_path, "w+") do |file|
             file.write new_contents
           end
@@ -60,7 +60,7 @@ module Mono
 
         private
 
-        VERSION_REGEX = /@version "(.*)"$/.freeze
+        VERSION_REGEX = /(@version|version:) "(.*)"(,?)$/.freeze
         DEPENDENCY_REGEX = /^\s*{:(.*), "(.*)"}/.freeze
 
         def read_mix_exs

--- a/lib/mono/version_object.rb
+++ b/lib/mono/version_object.rb
@@ -91,5 +91,9 @@ module Mono
         prerelease_version
       ].compact
     end
+
+    def eql?(other)
+      segments == other.segments
+    end
   end
 end

--- a/spec/lib/mono/cli/publish/elixir_spec.rb
+++ b/spec/lib/mono/cli/publish/elixir_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Mono::Cli::Publish do
       OUTPUT
 
       in_project do
-        expect(File.read("mix.exs")).to include(%(@version "#{next_version}"))
+        expect(File.read("mix.exs")).to include(%(version: "#{next_version}",))
         expect(current_package_changeset_files.length).to eql(0)
 
         changelog = File.read("CHANGELOG.md")
@@ -94,7 +94,7 @@ RSpec.describe Mono::Cli::Publish do
 
       in_project do
         in_package :package_a do
-          expect(File.read("mix.exs")).to include(%(@version "#{next_version_a}"))
+          expect(File.read("mix.exs")).to include(%(version: "#{next_version_a}",))
           expect(current_package_changeset_files.length).to eql(0)
 
           changelog = File.read("CHANGELOG.md")
@@ -166,7 +166,7 @@ RSpec.describe Mono::Cli::Publish do
 
       in_project do
         in_package :jason do
-          expect(File.read("mix.exs")).to include(%(@version "#{next_version_a}"))
+          expect(File.read("mix.exs")).to include(%(version: "#{next_version_a}",))
           expect(current_package_changeset_files.length).to eql(0)
 
           changelog = File.read("CHANGELOG.md")
@@ -175,7 +175,7 @@ RSpec.describe Mono::Cli::Publish do
         end
 
         in_package :package_b do
-          expect(File.read("mix.exs")).to include(%(@version "#{next_version_b}"))
+          expect(File.read("mix.exs")).to include(%(version: "#{next_version_b}",))
           expect(current_package_changeset_files.length).to eql(0)
 
           changelog = File.read("CHANGELOG.md")

--- a/spec/lib/mono/languages/elixir/package_spec.rb
+++ b/spec/lib/mono/languages/elixir/package_spec.rb
@@ -44,11 +44,12 @@ RSpec.describe Mono::Languages::Elixir::Package do
     end
   end
 
-  def create_package_with_dependencies(path, dependencies)
+  def create_package_with_dependencies(path, dependencies, version_in_module_attribute = true) # rubocop:disable Style/OptionalBooleanParameter
     prepare_new_project do
       create_package path do
         create_package_mix :version => "1.2.3",
-          :dependencies => dependencies
+          :dependencies => dependencies,
+          :version_in_module_attribute? => version_in_module_attribute
       end
     end
   end

--- a/spec/lib/mono/languages/elixir/package_spec.rb
+++ b/spec/lib/mono/languages/elixir/package_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe Mono::Languages::Elixir::Package do
         expect(package.current_version).to eql(Mono::Version.new(1, 2, 3))
       end
     end
+
+    context "with a version set in a module attribute" do
+      it "extracts the current version" do
+        package_name = "test_package"
+        create_package_with_dependencies package_name, {}, true
+
+        package = package_for_path(package_name)
+        expect(package.current_version).to eql(Mono::Version.new(1, 2, 3))
+      end
+    end
   end
 
   describe "#dependencies" do
@@ -44,7 +54,7 @@ RSpec.describe Mono::Languages::Elixir::Package do
     end
   end
 
-  def create_package_with_dependencies(path, dependencies, version_in_module_attribute = true) # rubocop:disable Style/OptionalBooleanParameter
+  def create_package_with_dependencies(path, dependencies, version_in_module_attribute = false) # rubocop:disable Style/OptionalBooleanParameter
     prepare_new_project do
       create_package path do
         create_package_mix :version => "1.2.3",

--- a/spec/lib/mono/languages/elixir/package_spec.rb
+++ b/spec/lib/mono/languages/elixir/package_spec.rb
@@ -3,6 +3,18 @@
 RSpec.describe Mono::Languages::Elixir::Package do
   let(:config) { mono_config }
 
+  describe "#current_version" do
+    context "with a version set in the project block" do
+      it "extracts the current version" do
+        package_name = "test_package"
+        create_package_with_dependencies package_name, {}
+
+        package = package_for_path(package_name)
+        expect(package.current_version).to eql(Mono::Version.new(1, 2, 3))
+      end
+    end
+  end
+
   describe "#dependencies" do
     context "without dependencies" do
       it "returns empty hash" do

--- a/spec/support/helpers/project_helper.rb
+++ b/spec/support/helpers/project_helper.rb
@@ -216,17 +216,23 @@ module ProjectHelper
         custom_config.fetch(:dependencies, []).map do |dependency, version|
           %({:#{dependency}, "#{version}"})
         end
+
+      version = custom_config.fetch(:version)
+      version_in_module_attribute = custom_config.fetch(:version_in_module_attribute?, false)
+
+      module_attributes = ["@source_url \"https://github.com/appsignal/test-package\""]
+      module_attributes << "  @version \"#{version}\"" if version_in_module_attribute
+
       spec = <<~SPEC
         defmodule MyPackage.Mixfile do
           use Mix.Project
 
-          @source_url "https://github.com/appsignal/test-package"
-          @version "#{custom_config.fetch(:version)}"
+          #{module_attributes.join("\n")}
 
           def project do
             [
               app: :#{in_package? ? current_package : current_project},
-              version: @version,
+              version: #{version_in_module_attribute ? "@version" : "\"#{version}\""},
               name: "My Package",
               description: "Dummy package description",
               package: package(),


### PR DESCRIPTION
The current version of mono raises an exception when running `mono publish` on  https://github.com/appsignal/appsignal-elixir-phoenix:

    ~/Appsignal/appsignal-elixir-phoenix (main) $ DRY_RUN=true mono publish
    The following packages will be published (or not):
    - appsignal-elixir-phoenix:
    An unexpected error was encountered during the `mono publish` command. Stopping operation.
    Traceback (most recent call last):
    	9: from /Users/jeffkreeftmeijer/mono/bin/mono:9:in `<main>'
    	8: from /Users/jeffkreeftmeijer/mono/lib/mono/cli.rb:148:in `execute'
    	7: from /Users/jeffkreeftmeijer/mono/lib/mono/cli.rb:167:in `execute_command'
    	6: from /Users/jeffkreeftmeijer/mono/lib/mono/cli/publish.rb:35:in `execute'
    	5: from /Users/jeffkreeftmeijer/mono/lib/mono/cli/publish.rb:74:in `print_summary'
    	4: from /Users/jeffkreeftmeijer/mono/lib/mono/cli/publish.rb:74:in `each'
    	3: from /Users/jeffkreeftmeijer/mono/lib/mono/cli/publish.rb:76:in `block in print_summary'
    	2: from /Users/jeffkreeftmeijer/mono/lib/mono/cli/publish.rb:93:in `print_package_summary'
    	1: from /Users/jeffkreeftmeijer/mono/lib/mono/package.rb:84:in `current_tag'
    /Users/jeffkreeftmeijer/mono/lib/mono/languages/elixir/package.rb:12:in `current_version': undefined method `[]' for nil:NilClass (NoMethodError)

This happens because it assumes Elixir projects have a module attribute named `@version` in their mix.exs file. While that’s true for https://github.com/appsignal/appsignal-elixix, that’s not the case for the Phoenix integration, as it’s not required there.

This patch switches the main test case from a setup that uses a module attribute to set the version number to one that does not, and adds a regression test for setups that do use the module attributes. It then updates both version reading and writing to handle Elixir projects with their version options directly placed in their `mix.exs` project blocks.