### PR TITLE
Add mono-dev executable

### DIFF
--- a/.changesets/add-mono-dev-command.md
+++ b/.changesets/add-mono-dev-command.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Add `mono-dev` executable to allow for testing mono. The `mono` executable will not allow usage of mono with uncommitted changes. This will prevent accidental usage of mono with uncommitted changes that would cause mono to crash unexpectedly.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,9 @@ AllCops:
   CacheRootDirectory: ./tmp
   NewCops: enable
 
+Style/SpecialGlobalVars:
+  Enabled: false
+
 Style/RescueStandardError:
   Enabled: false
 

--- a/bin/mono
+++ b/bin/mono
@@ -1,6 +1,21 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+git_status = `git status -s`
+unless $?.success?
+  puts "ERROR: Unable to perform the mono production check. Is git installed?"
+  exit 1
+end
+
+unless git_status.empty?
+  puts "ERROR: The mono repository has been modified locally. " \
+    "You are using the `mono` executable which is only meant for " \
+    "'production' use."
+  puts "Please use the `mono-dev` executable if you want to use uncommitted " \
+    "changes to _test_ mono itself."
+  exit 1
+end
+
 $LOAD_PATH << File.expand_path(File.join(__dir__, "..", "lib"))
 
 require "mono"

--- a/bin/mono-dev
+++ b/bin/mono-dev
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH << File.expand_path(File.join(__dir__, "..", "lib"))
+
+require "mono"
+require "mono/cli"
+
+Mono::Cli::Wrapper.new(ARGV).execute


### PR DESCRIPTION
Add `mono-dev` executable to allow for testing mono. The `mono`
executable will not allow usage of mono with uncommitted changes. This
will prevent accidental usage of mono with uncommitted changes that
would cause mono to crash unexpectedly.

I've added another `mono-dev` executable that behaves the same way as
`mono` would previously. And added a check to `mono` to see if there are
any uncommitted changes and exit if there are any.

Closes #20

[skip review]