### PR TITLE
Retry publish command on failure

### DIFF
--- a/.changesets/retry-failed-publish-commands.md
+++ b/.changesets/retry-failed-publish-commands.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Retry failed publish commands. When a publish command like `gem push` fails, prompt the user to retry it rather than fail the entire publish process.

--- a/lib/mono.rb
+++ b/lib/mono.rb
@@ -39,6 +39,7 @@ module Mono
   end
 end
 
+require "mono/shell"
 require "mono/version"
 require "mono/version_object"
 require "mono/version_promoter"

--- a/lib/mono/cli.rb
+++ b/lib/mono/cli.rb
@@ -6,40 +6,8 @@ require "optparse"
 
 module Mono
   module Cli
-    module Helpers
-      def ask_for_input
-        value = $stdin.gets
-        value ? value.chomp : ""
-      rescue Interrupt
-        puts "\nExiting..."
-        exit 1
-      end
-
-      def required_input(prompt)
-        loop do
-          print prompt
-          value = ask_for_input
-          return value unless value.empty?
-        end
-      end
-
-      def yes_or_no(prompt, options = {})
-        loop do
-          print prompt
-          input = ask_for_input.strip
-          input = options[:default] if input.empty? && options[:default]
-          case input
-          when "y", "Y", "yes"
-            return true
-          when "n", "N", "no"
-            return false
-          end
-        end
-      end
-    end
-
     class Base
-      include Helpers
+      include Shell
       include Command::Helper
 
       def initialize(options = {})

--- a/lib/mono/cli/init.rb
+++ b/lib/mono/cli/init.rb
@@ -3,7 +3,7 @@
 module Mono
   module Cli
     class Init
-      include Helpers
+      include Shell
 
       def execute
         config = {}

--- a/lib/mono/languages/elixir/package.rb
+++ b/lib/mono/languages/elixir/package.rb
@@ -39,7 +39,7 @@ module Mono
         end
 
         def publish_package
-          run_command_in_package "mix hex.publish --yes"
+          run_command_in_package "mix hex.publish --yes", :retry => true
         end
 
         def build_package

--- a/lib/mono/languages/nodejs/package.rb
+++ b/lib/mono/languages/nodejs/package.rb
@@ -57,7 +57,8 @@ module Mono
             options << "--tag #{next_version.prerelease_type}"
           end
           options << "--new-version #{next_version}" if npm_client == "yarn"
-          run_client_command_in_package "publish #{options.join(" ")}".strip
+          run_client_command_in_package "publish #{options.join(" ")}".strip,
+            :retry => true
         end
 
         def build_package
@@ -108,8 +109,8 @@ module Mono
           run_command "#{npm_client} #{command}"
         end
 
-        def run_client_command_in_package(command)
-          run_command_in_package "#{npm_client} #{command}"
+        def run_client_command_in_package(command, options = {})
+          run_command_in_package "#{npm_client} #{command}", options
         end
 
         def run_client_command_for_package(command)

--- a/lib/mono/languages/ruby/package.rb
+++ b/lib/mono/languages/ruby/package.rb
@@ -56,7 +56,7 @@ module Mono
           gem_files = fetch_gem_files_paths
           if gem_files.any?
             gem_files.each do |gem_file|
-              run_command "gem push #{gem_file}"
+              run_command "gem push #{gem_file}", :retry => true
             end
           else
             raise "No gemfiles found in `#{gem_files_dir || "."}`"

--- a/lib/mono/package.rb
+++ b/lib/mono/package.rb
@@ -113,7 +113,7 @@ module Mono
     def publish_next_version
       if config.command?("publish")
         # Custom command configured
-        run_command_in_package config.command("publish")
+        run_command_in_package config.command("publish"), :retry => true
       else
         publish_package
       end
@@ -180,8 +180,8 @@ module Mono
     end
     # :nocov:
 
-    def run_command_in_package(command)
-      run_command command, :dir => path
+    def run_command_in_package(command, options = {})
+      run_command command, { :dir => path }.merge(options)
     end
 
     def build_tag(version)

--- a/lib/mono/shell.rb
+++ b/lib/mono/shell.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Mono
+  module Shell
+    module_function
+
+    def ask_for_input
+      value = $stdin.gets
+      value ? value.chomp : ""
+    rescue Interrupt
+      puts "\nExiting..."
+      exit 1
+    end
+
+    def required_input(prompt)
+      loop do
+        print prompt
+        value = ask_for_input
+        return value unless value.empty?
+      end
+    end
+
+    def yes_or_no(prompt, options = {})
+      loop do
+        print prompt
+        input = ask_for_input.strip
+        input = options[:default] if input.empty? && options[:default]
+        case input
+        when "y", "Y", "yes"
+          return true
+        when "n", "N", "no"
+          return false
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/mono/cli/publish/elixir_spec.rb
+++ b/spec/lib/mono/cli/publish/elixir_spec.rb
@@ -111,6 +111,42 @@ RSpec.describe Mono::Cli::Publish do
       ])
       expect(exit_status).to eql(0), output
     end
+
+    context "with failing publish command" do
+      it "retries to publish" do
+        fail_command = "exit 1"
+        prepare_elixir_project do
+          create_package_mix :version => "1.2.3"
+          add_changeset :patch
+        end
+        confirm_publish_package
+        add_cli_input "y" # Retry command
+        add_cli_input "n" # Don't retry command
+        output = run_publish_process(
+          :stubbed_commands => [/^git push/],
+          :failed_commands => [/^mix hex.publish package --yes/]
+        )
+
+        project_dir = "/#{current_project}"
+        next_version = "1.2.4"
+
+        expect(output).to include(<<~OUTPUT), output
+          #{fail_command}
+          Error: Command failed. Do you want to retry? (Y/n): #{fail_command}
+          Error: Command failed. Do you want to retry? (Y/n): Error: Command failed with status `1`
+        OUTPUT
+
+        expect(performed_commands).to eql([
+          [project_dir, "mix deps.get"],
+          [project_dir, "mix compile"],
+          [project_dir, "git add -A"],
+          [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}' -m '[ci skip]'"],
+          [project_dir, "git tag v#{next_version}"],
+          [project_dir, "mix hex.publish package --yes"]
+        ])
+        expect(exit_status).to eql(1), output
+      end
+    end
   end
 
   context "with mono Elixir project" do
@@ -278,15 +314,18 @@ RSpec.describe Mono::Cli::Publish do
     end
   end
 
-  def run_publish_process
+  def run_publish_process(failed_commands: [], stubbed_commands: nil)
+    stubbed_commands ||= [/^mix hex.publish package --yes/, /^git push/]
     capture_stdout do
       in_project do
         add_changeset(:patch)
 
         perform_commands do
-          stub_commands [/^mix hex.publish package --yes/, /^git push/] do
-            run_bootstrap
-            run_publish
+          fail_commands failed_commands do
+            stub_commands stubbed_commands do
+              run_bootstrap
+              run_publish
+            end
           end
         end
       end

--- a/spec/lib/mono/cli/publish/nodejs_spec.rb
+++ b/spec/lib/mono/cli/publish/nodejs_spec.rb
@@ -185,6 +185,44 @@ RSpec.describe Mono::Cli::Publish do
         ])
         expect(exit_status).to eql(0), output
       end
+
+      context "with failing publish command" do
+        it "retries to publish" do
+          fail_command = "exit 1"
+          prepare_nodejs_project do
+            create_package_json :version => "1.2.3"
+            add_changeset :patch
+          end
+          confirm_publish_package
+          add_cli_input "y" # Retry command
+          add_cli_input "n" # Don't retry command
+          output = run_publish_process(
+            :stubbed_commands => [/^git push/],
+            :failed_commands => [/^npm publish/]
+          )
+
+          project_dir = "/#{current_project}"
+          next_version = "1.2.4"
+
+          expect(output).to include(<<~OUTPUT), output
+            #{fail_command}
+            Error: Command failed. Do you want to retry? (Y/n): #{fail_command}
+            Error: Command failed. Do you want to retry? (Y/n): Error: Command failed with status `1`
+          OUTPUT
+
+          expect(performed_commands).to eql([
+            [project_dir, "npm install"],
+            [project_dir, "npm link"],
+            [project_dir, "npm run build"],
+            [project_dir, "git add -A"],
+            [project_dir,
+             "git commit -m 'Publish packages' -m '- v#{next_version}' -m '[ci skip]'"],
+            [project_dir, "git tag v#{next_version}"],
+            [project_dir, "npm publish"]
+          ])
+          expect(exit_status).to eql(1), output
+        end
+      end
     end
 
     context "with mono Node.js project" do
@@ -746,13 +784,16 @@ RSpec.describe Mono::Cli::Publish do
     end
   end
 
-  def run_publish_process(args = [])
+  def run_publish_process(args = [], failed_commands: [], stubbed_commands: nil)
+    stubbed_commands ||= [/^(npm|yarn) publish/, /^git push/]
     capture_stdout do
       in_project do
         perform_commands do
-          stub_commands [/^(npm|yarn) publish/, /^git push/] do
-            run_bootstrap
-            run_publish(args)
+          fail_commands failed_commands do
+            stub_commands stubbed_commands do
+              run_bootstrap
+              run_publish(args)
+            end
           end
         end
       end

--- a/spec/support/helpers/command_helper.rb
+++ b/spec/support/helpers/command_helper.rb
@@ -21,6 +21,14 @@ module CommandHelper
     yield
   end
 
+  # When a command is wrapped with {perform_commands} they are actually
+  # executed. If you want cause one to fail deliberatly (to test the error
+  # handling), use this helper.
+  def fail_commands(command_matchers)
+    command_matchers.each { |matcher| Testing.failed_commands << matcher }
+    yield
+  end
+
   def exit_status
     Testing.exit_status || 0
   end

--- a/spec/testing.rb
+++ b/spec/testing.rb
@@ -36,6 +36,10 @@ module Testing
     def stubbed_commands
       @stubbed_commands ||= []
     end
+
+    def failed_commands
+      @failed_commands ||= []
+    end
   end
 
   module Command
@@ -53,6 +57,10 @@ module Testing
 
       return unless Testing.perform_commands?
       return if Testing.stubbed_commands.find { |matcher| matcher.match?(command) }
+
+      # Overwrite deliberatly failing commands with `exit 1` to force the
+      # failure
+      @command = "exit 1" if Testing.failed_commands.find { |matcher| matcher.match?(command) }
 
       super
     end


### PR DESCRIPTION
## Retry publish command on failure

When publishing a package and the command would fail, mono would exit
entirely. This would happen if a user would enter an invalid OTP code
during the process for example.

When in a mono package repo this could exit the entire process, such as
like on package 3 of 10. The only way to publish the package properly
then (as part was already published) is to publish them manually.

This retry option will prompt users on failure of the command to retry
it.

I've only added it to the publish command for now because that's the
only problematic one I can think of right now. If the build step fails
nothing is in a state of being half published yet. Pushing the Git
branch and tags should also be easy to do manually.

Fixes #24

## Move shell methods to a general helper

The helpers that interact with the user will need to be called from
outside of the `Cli` namespace in the future. I need classes loaded
before the `Cli` classes to be able to require a module like the `Shell`
one to access those methods.

I've added `module_function` to the module. This makes it possible to
call the methods on the module directly, without having to include the
module.

```
Shell.ask_for_input
Shell.required_input "Your name?"
Shell.yes_or_no "Cake?"
``` 

