### PR TITLE
Production check fixes

### DIFF
--- a/.changesets/check-git-branch-for-mono.md
+++ b/.changesets/check-git-branch-for-mono.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Check Git branch for mono to prevent accidental usage of mono on an unmerged branch.

--- a/.changesets/fix-mono-production-check-directory.md
+++ b/.changesets/fix-mono-production-check-directory.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Fix mono production check directory. It would perform the check in the current directory, not the mono install directory.

--- a/.changesets/skip-git-check-if-git-command-fails.md
+++ b/.changesets/skip-git-check-if-git-command-fails.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Skip Git check if Git command fails. If `git status` fails in the `mono` directory, skip the check. It's probably a production download.

--- a/bin/mono
+++ b/bin/mono
@@ -2,28 +2,25 @@
 # frozen_string_literal: true
 
 git_status = `git status -s`
-unless $?.success?
-  puts "ERROR: Unable to perform the mono production check. Is git installed?"
-  exit 1
-end
+if $?.success?
+  unless git_status.empty?
+    puts "ERROR: The mono repository has been modified locally. " \
+      "You are using the `mono` executable which is only meant for " \
+      "'production' use."
+    puts "Please use the `mono-dev` executable if you want to use " \
+      "uncommitted changes to _test_ mono itself."
+    exit 1
+  end
 
-unless git_status.empty?
-  puts "ERROR: The mono repository has been modified locally. " \
-    "You are using the `mono` executable which is only meant for " \
-    "'production' use."
-  puts "Please use the `mono-dev` executable if you want to use uncommitted " \
-    "changes to _test_ mono itself."
-  exit 1
-end
-
-current_branch = `git rev-parse --abbrev-ref HEAD`.chomp
-unless current_branch == "main"
-  puts "ERROR: The mono repository is not on the `main` branch. " \
-    "Please switch to the main branch to ensure you're using a released " \
-    "version."
-  puts "Please use the `mono-dev` executable if you want to use uncommitted " \
-    "changes to _test_ mono itself."
-  exit 1
+  current_branch = `git rev-parse --abbrev-ref HEAD`.chomp
+  unless current_branch == "main"
+    puts "ERROR: The mono repository is not on the `main` branch. " \
+      "Please switch to the main branch to ensure you're using a released " \
+      "version."
+    puts "Please use the `mono-dev` executable if you want to use " \
+      "uncommitted changes to _test_ mono itself."
+    exit 1
+  end
 end
 
 $LOAD_PATH << File.expand_path(File.join(__dir__, "..", "lib"))

--- a/bin/mono
+++ b/bin/mono
@@ -16,6 +16,16 @@ unless git_status.empty?
   exit 1
 end
 
+current_branch = `git rev-parse --abbrev-ref HEAD`.chomp
+unless current_branch == "main"
+  puts "ERROR: The mono repository is not on the `main` branch. " \
+    "Please switch to the main branch to ensure you're using a released " \
+    "version."
+  puts "Please use the `mono-dev` executable if you want to use uncommitted " \
+    "changes to _test_ mono itself."
+  exit 1
+end
+
 $LOAD_PATH << File.expand_path(File.join(__dir__, "..", "lib"))
 
 require "mono"

--- a/bin/mono
+++ b/bin/mono
@@ -1,7 +1,19 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-git_status = `git status -s`
+module MonoCheck
+  def self.run(command)
+    read, write = IO.pipe
+    pid = spawn command,
+      [:out, :err] => write,
+      :chdir => __dir__
+    Process.wait pid
+    write.close
+    read.read
+  end
+end
+
+git_status = MonoCheck.run("git status -s")
 if $?.success?
   unless git_status.empty?
     puts "ERROR: The mono repository has been modified locally. " \
@@ -12,7 +24,7 @@ if $?.success?
     exit 1
   end
 
-  current_branch = `git rev-parse --abbrev-ref HEAD`.chomp
+  current_branch = MonoCheck.run("git rev-parse --abbrev-ref HEAD").chomp
   unless current_branch == "main"
     puts "ERROR: The mono repository is not on the `main` branch. " \
       "Please switch to the main branch to ensure you're using a released " \


### PR DESCRIPTION
[skip review]

## Check Git branch in production mode

When the current Git branch isn't the `main` branch, exit the `mono`
executable. This is to ensure that users don't accidentally use an
unmerged and unreviewed branch.

Developers can use the `mono-dev` executable instead.

## Skip mono production check if Git check fails

Skip Git check if Git command fails. If `git status` fails in the `mono`
directory, skip the check. It's probably a production download.

## Fix mono production check directory

The Git commands were run in the directory mono was run in as well, not
necessarily the directory in which the mono Git repository is present.

Use chdir to temporarily run the command in mono installation directory.

I'm using spawn instead of the backticks to "chdir". I could have also
wrapped it in `Dir.chdir { ... }`, but it seemed better to only run the
command in that directory rather than "move" the entire program within
that block to the installation directory.

