### PR TITLE
Print changeset summaries on publish

### DIFF
--- a/.changesets/print-changeset-summaries-on-publish.md
+++ b/.changesets/print-changeset-summaries-on-publish.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Print changeset summaries on publish. This makes it easier to tell which changes are about to be published for every package.

--- a/lib/mono/changeset.rb
+++ b/lib/mono/changeset.rb
@@ -6,6 +6,8 @@ module Mono
   class Changeset
     attr_reader :path, :message
 
+    # Supported changeset version bumps, sorted by biggest change. The "major"
+    # change being the largest, index 0, and patch being the lowest, index 2.
     SUPPORTED_BUMPS = %w[major minor patch].freeze
     YAML_FRONT_MATTER_REGEXP =
       /\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)/m.freeze
@@ -56,6 +58,15 @@ module Mono
 
     def bump
       @metadata["bump"]
+    end
+
+    # Returns the number equivilant of the version bump string. A lower number
+    # is a higher change.
+    # - major == 0
+    # - minor == 1
+    # - patch == 2
+    def bump_index
+      SUPPORTED_BUMPS.index @metadata["bump"]
     end
 
     def date

--- a/lib/mono/cli/publish.rb
+++ b/lib/mono/cli/publish.rb
@@ -74,6 +74,7 @@ module Mono
         packages.each do |package|
           if package.will_update?
             print_package_summary(package)
+            print_package_changesets(package)
           else
             puts "- #{package.name}: (Will not publish)"
           end
@@ -92,6 +93,23 @@ module Mono
         puts "- #{package.name}:"
         puts "  Current version: #{package.current_tag}"
         puts "  Next version:    #{package.next_tag} (#{package.next_bump})"
+      end
+
+      def print_package_changesets(package)
+        puts "  Changesets:"
+        # Sort by biggest version bump at the top
+        changesets = package.changesets.changesets.sort_by(&:bump_index)
+        changesets.each do |changeset|
+          # Clean up the description from indenting and new lines so the
+          # formatting doesn't break
+          description = changeset.message
+            .gsub(/\n\s+/, " ") # Strip out any indenting in new lines
+            .tr("\n", " ") # Strip out any remaining new lines
+          # Trim long changeset messages
+          description = "#{description[0...100]}..." if description.length > 100
+          puts "  - #{changeset.bump}: #{changeset.path}"
+          puts "      #{description}"
+        end
       end
 
       def update_changelog(packages)

--- a/spec/lib/mono/changeset_spec.rb
+++ b/spec/lib/mono/changeset_spec.rb
@@ -72,34 +72,47 @@ RSpec.describe Mono::Changeset do
         "Message"
       )
     end
-    subject { changeset.bump }
 
     describe "with major" do
       let(:bump) { "major" }
-      it { is_expected.to eql("major") }
+
+      it "return major" do
+        expect(changeset.bump).to eql("major")
+        expect(changeset.bump_index).to eql(0)
+      end
     end
 
     describe "with minor" do
       let(:bump) { "minor" }
-      it { is_expected.to eql("minor") }
+
+      it "returns minor" do
+        expect(changeset.bump).to eql("minor")
+        expect(changeset.bump_index).to eql(1)
+      end
     end
 
     describe "with patch" do
       let(:bump) { "patch" }
-      it { is_expected.to eql("patch") }
+
+      it "returns patch" do
+        expect(changeset.bump).to eql("patch")
+        expect(changeset.bump_index).to eql(2)
+      end
     end
 
     describe "with other" do
       let(:bump) { "random" }
       it "raises an UnknownBumpTypeError" do
-        expect { subject }.to raise_error(Mono::Changeset::UnknownBumpTypeError)
+        expect { changeset.bump }.to raise_error(Mono::Changeset::UnknownBumpTypeError)
+        expect { changeset.bump_index }.to raise_error(Mono::Changeset::UnknownBumpTypeError)
       end
     end
 
     describe "without bump" do
       let(:bump) { "" }
       it "raises an UnknownBumpTypeError" do
-        expect { subject }.to raise_error(Mono::Changeset::UnknownBumpTypeError)
+        expect { changeset.bump }.to raise_error(Mono::Changeset::UnknownBumpTypeError)
+        expect { changeset.bump_index }.to raise_error(Mono::Changeset::UnknownBumpTypeError)
       end
     end
   end

--- a/spec/lib/mono/cli/publish/elixir_spec.rb
+++ b/spec/lib/mono/cli/publish/elixir_spec.rb
@@ -304,19 +304,21 @@ RSpec.describe Mono::Cli::Publish do
 
   def run_publish_process(failed_commands: [], stubbed_commands: nil)
     stubbed_commands ||= [/^mix hex.publish package --yes/, /^git push/]
-    capture_stdout do
-      in_project do
-        add_changeset(:patch)
+    output =
+      capture_stdout do
+        in_project do
+          add_changeset(:patch)
 
-        perform_commands do
-          fail_commands failed_commands do
-            stub_commands stubbed_commands do
-              run_bootstrap
-              run_publish
+          perform_commands do
+            fail_commands failed_commands do
+              stub_commands stubbed_commands do
+                run_bootstrap
+                run_publish
+              end
             end
           end
         end
       end
-    end
+    strip_changeset_output output
   end
 end

--- a/spec/lib/mono/cli/publish/elixir_spec.rb
+++ b/spec/lib/mono/cli/publish/elixir_spec.rb
@@ -302,18 +302,6 @@ RSpec.describe Mono::Cli::Publish do
     end
   end
 
-  def prepare_elixir_project(config = {})
-    prepare_new_project do
-      create_mono_config(
-        {
-          "language" => "elixir",
-          "publish" => { "command" => "mix hex.publish package --yes" }
-        }.merge(config)
-      )
-      yield
-    end
-  end
-
   def run_publish_process(failed_commands: [], stubbed_commands: nil)
     stubbed_commands ||= [/^mix hex.publish package --yes/, /^git push/]
     capture_stdout do

--- a/spec/lib/mono/cli/publish/nodejs_spec.rb
+++ b/spec/lib/mono/cli/publish/nodejs_spec.rb
@@ -786,17 +786,19 @@ RSpec.describe Mono::Cli::Publish do
 
   def run_publish_process(args = [], failed_commands: [], stubbed_commands: nil)
     stubbed_commands ||= [/^(npm|yarn) publish/, /^git push/]
-    capture_stdout do
-      in_project do
-        perform_commands do
-          fail_commands failed_commands do
-            stub_commands stubbed_commands do
-              run_bootstrap
-              run_publish(args)
+    output =
+      capture_stdout do
+        in_project do
+          perform_commands do
+            fail_commands failed_commands do
+              stub_commands stubbed_commands do
+                run_bootstrap
+                run_publish(args)
+              end
             end
           end
         end
       end
-    end
+    strip_changeset_output output
   end
 end

--- a/spec/lib/mono/cli/publish/ruby_spec.rb
+++ b/spec/lib/mono/cli/publish/ruby_spec.rb
@@ -476,16 +476,18 @@ RSpec.describe Mono::Cli::Publish do
   end
 
   def run_publish_process(failed_commands: [], stubbed_commands: [/^gem push/, /^git push/])
-    capture_stdout do
-      in_project do
-        perform_commands do
-          fail_commands failed_commands do
-            stub_commands stubbed_commands do
-              run_publish
+    output =
+      capture_stdout do
+        in_project do
+          perform_commands do
+            fail_commands failed_commands do
+              stub_commands stubbed_commands do
+                run_publish
+              end
             end
           end
         end
       end
-    end
+    strip_changeset_output output
   end
 end

--- a/spec/support/helpers/project_helper.rb
+++ b/spec/support/helpers/project_helper.rb
@@ -51,6 +51,18 @@ module ProjectHelper
     end
   end
 
+  def prepare_elixir_project(config = {})
+    prepare_new_project do
+      create_mono_config(
+        {
+          "language" => "elixir",
+          "publish" => { "command" => "mix hex.publish package --yes" }
+        }.merge(config)
+      )
+      yield
+    end
+  end
+
   def in_project(&block)
     # Execute block in test dir
     Dir.chdir(current_project_dir, &block)

--- a/spec/support/helpers/publish_helper.rb
+++ b/spec/support/helpers/publish_helper.rb
@@ -37,4 +37,24 @@ module PublishHelper
   def run_bootstrap(args = [])
     Mono::Cli::Wrapper.new(["bootstrap"] + args).execute
   end
+
+  # Strip all changeset summary output from the output string.
+  # Useful when only testing version changes, and not the summary itself.
+  def strip_changeset_output(output)
+    new_output = []
+    changesets = false
+    output.lines do |line|
+      # When a line doesn't start with space, it means we're not printing
+      # changesets from a package anymore
+      changesets = false unless line.start_with?(" ")
+      next if changesets # Skip all changeset lines
+
+      if line == "  Changesets:\n" # Changeset summary detected, skipping
+        changesets = true
+        next
+      end
+      new_output << line
+    end
+    new_output.join
+  end
 end


### PR DESCRIPTION
## Print changeset summaries on publish 

To make it easier to tell what's being published, print a summary for
every changeset in every package.

The changeset contents are printed as single lines (even if the actual
changeset file contents is multi line) and is trimmed to maximum 100
characters to not break the CLI output formatting.

The changesets are sorted by type of version bump, with "major" version
bumps listed at the top and patch releases at the bottom.

The additional output made it a bit more difficult to test, which is why
I added a `strip_changeset_output` helper that we can run the output
through to filter out the changeset output for tests that don't actually
test it. We don't need to test it every time, only the specific tests
that test this summary.

Closes #21

## Move prepare_elixir_project to shared module

By moving the helper to a shared module, the `prepare_elixir_project`
helper can be reused by other specs to quickly build an Elixir test
project.
