### PR TITLE
Improve parsing of package index on changeset add

### DIFF
--- a/.changesets/fix-changeset-package-index-validation.md
+++ b/.changesets/fix-changeset-package-index-validation.md
@@ -1,0 +1,5 @@
+---
+bump: "patch"
+---
+
+Validate user input of the package number for changesets in mono repositories better. Non number characters and other invalid strings will prompt the user again to enter a valid package number.

--- a/lib/mono/cli/changeset/add.rb
+++ b/lib/mono/cli/changeset/add.rb
@@ -53,13 +53,13 @@ module Mono
             end
             package_index =
               required_input("Select package 1-#{packages.length}: ").to_i
-
-            package = packages[package_index - 1]
-            if package
-              break package
-            else
-              puts "Unknown package selected. Please select package."
+            package_index = parse_number(package_index)
+            if package_index&.positive?
+              package = packages[package_index - 1]
+              break package if package
             end
+
+            puts "Unknown package selected. Please select package."
           end
         end
 
@@ -74,6 +74,12 @@ module Mono
                 "Please specify supported bump type."
             end
           end
+        end
+
+        def parse_number(string)
+          Integer(string)
+        rescue ArgumentError
+          # Do nothing, invalid value
         end
       end
     end

--- a/spec/lib/mono/cli/changeset/add_spec.rb
+++ b/spec/lib/mono/cli/changeset/add_spec.rb
@@ -143,6 +143,8 @@ RSpec.describe Mono::Cli::Changeset do
       prepare_project :elixir_mono
 
       add_cli_input "" # User presses enter without input
+      add_cli_input "x" # Invalid value
+      add_cli_input "0" # Invalid index, no zero package
       add_cli_input "3" # Invalid index, only 2 packages
       add_cli_input "1" # First package
       add_cli_input "My Awes/o\\me patch"
@@ -162,7 +164,7 @@ RSpec.describe Mono::Cli::Changeset do
         "Changeset file created at #{changeset_path}",
         "Do you want to open this file to add more information? (y/N):"
       ), output
-      expect(output.scan(/Select package 1-2/).length).to eql(3)
+      expect(output.scan(/Select package 1-2/).length).to eql(5)
       in_project do
         in_package :package_one do
           expect(current_package_changeset_files.length).to eql(1)


### PR DESCRIPTION
If a user entered "x" when the package index prompt asks for a number it
tried to find a package for that index, which doesn't work.

Validate if the given value is a number and only then find the package
that belongs to that number.