### PR TITLE
Add types to changesets

### DIFF
--- a/.changesets/add-types-for-changesets.md
+++ b/.changesets/add-types-for-changesets.md
@@ -1,0 +1,6 @@
+---
+bump: "minor"
+type: "add"
+---
+
+Add types to changesets. The following types are supported: add, change, deprecate, remove, fix and security. Use the appropriate one for the change and the changelog will include sections for every present type of change. This will make it easier for readers to understand the impact of a new release's changes.

--- a/lib/mono/changeset.rb
+++ b/lib/mono/changeset.rb
@@ -6,6 +6,15 @@ module Mono
   class Changeset
     attr_reader :path, :message
 
+    # Sorted Hash of supported types in the changelog
+    SUPPORTED_TYPES = {
+      "Added" => "add",
+      "Changed" => "change",
+      "Deprecated" => "deprecate",
+      "Removed" => "remove",
+      "Fixed" => "fix",
+      "Security" => "security"
+    }.freeze
     # Supported changeset version bumps, sorted by biggest change. The "major"
     # change being the largest, index 0, and patch being the lowest, index 2.
     SUPPORTED_BUMPS = %w[major minor patch].freeze
@@ -54,6 +63,10 @@ module Mono
           "Unknown bump type specified for changeset: `#{path}`. " \
           "Please specify either major, minor or patch."
       end
+    end
+
+    def type
+      @metadata["type"]
     end
 
     def bump

--- a/lib/mono/cli/changeset/add.rb
+++ b/lib/mono/cli/changeset/add.rb
@@ -21,12 +21,14 @@ module Mono
             required_input("Summarize the change (for changeset filename): ")
           filename = change_description.downcase.tr(". /\\", "-")
           filepath = File.join(dir, "#{filename}.md")
+          type = prompt_for_type
           bump = prompt_for_bump
 
           File.open(filepath, "w+") do |file|
             file.write(<<~CONTENTS)
               ---
               bump: "#{bump}"
+              type: "#{type}"
               ---
 
               #{change_description}
@@ -60,6 +62,28 @@ module Mono
             end
 
             puts "Unknown package selected. Please select package."
+          end
+        end
+
+        def prompt_for_type
+          types = Mono::Changeset::SUPPORTED_TYPES.keys
+          loop do
+            puts "What type of change is this: "
+
+            types.each_with_index do |label, index|
+              puts "#{index + 1}: #{label}"
+            end
+            type_index = required_input("Select type 1-#{types.length}: ")
+            type_index = parse_number(type_index)
+            if type_index&.positive?
+              type_key = types[type_index - 1]
+              if type_key
+                type = Mono::Changeset::SUPPORTED_TYPES[type_key]
+                break type if type
+              end
+            end
+
+            puts "Unknown type selected. Please select a type."
           end
         end
 

--- a/lib/mono/package.rb
+++ b/lib/mono/package.rb
@@ -45,7 +45,7 @@ module Mono
 
     def bump_version_to_final
       changesets.changesets << MemoryChangeset.new(
-        { "bump" => current_version.current_bump },
+        { "bump" => current_version.current_bump, "type" => "change" },
         "Package release."
       )
     end
@@ -65,7 +65,7 @@ module Mono
 
       @updated_dependencies[package.name] = package.next_version.to_s
       changesets.changesets << MemoryChangeset.new(
-        { "bump" => "patch" },
+        { "bump" => "patch", "type" => "change" },
         "Update #{package.name} dependency to #{package.next_version}."
       )
     end

--- a/spec/lib/mono/changeset_spec.rb
+++ b/spec/lib/mono/changeset_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Mono::Changeset do
             "- List item 2\n" \
             "- List item 3\n" \
             "- List item 4"
-          path = add_changeset :patch, message
+          path = add_changeset :patch, :message => message
           changeset = described_class.parse(path)
           expect(changeset.path).to eql(path)
           expect(changeset.bump).to eql("patch")
@@ -43,7 +43,7 @@ RSpec.describe Mono::Changeset do
             "- List item 2\n" \
             "- List item 3\n" \
             "- List item 4"
-          path = add_changeset :none, message
+          path = add_changeset :none, :message => message
           expect do
             described_class.parse(path)
           end.to raise_error(described_class::MetadataError)
@@ -55,7 +55,7 @@ RSpec.describe Mono::Changeset do
       it "raises a EmptyMessageError" do
         prepare_project :nodejs_npm_single
         in_project do
-          path = add_changeset :patch, ""
+          path = add_changeset :patch, :message => ""
           expect do
             described_class.parse(path)
           end.to raise_error(described_class::EmptyMessageError)

--- a/spec/lib/mono/cli/publish/base_spec.rb
+++ b/spec/lib/mono/cli/publish/base_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe Mono::Cli::Publish do
       it "prints changeset previews in the package summary" do
         prepare_elixir_project do
           create_package_mix :version => "1.2.3"
-          add_changeset(:patch, "a" * 101) # Limits to 100 characters in preview
-          add_changeset(:major, "This is a major changeset bump.\nLine 2.\nLine 3.")
+          add_changeset(:patch, :message => "a" * 101) # Limits to 100 characters in preview
+          add_changeset(:major, :message => "This is a major changeset bump.\nLine 2.\nLine 3.")
           add_changeset(:minor)
         end
         do_not_publish_package
@@ -111,13 +111,13 @@ RSpec.describe Mono::Cli::Publish do
         prepare_elixir_project "packages_dir" => "packages/" do
           create_package :package_a do
             create_package_mix :version => "1.2.3"
-            add_changeset(:patch, "a" * 101) # Limits to 100 characters in preview
-            add_changeset(:major, "This is a major changeset bump.\nLine 2.\nLine 3.")
+            add_changeset(:patch, :message => "a" * 101) # Limits to 100 characters in preview
+            add_changeset(:major, :message => "This is a major changeset bump.\nLine 2.\nLine 3.")
             add_changeset(:minor)
           end
           create_package :package_b do
             create_package_mix :version => "1.2.3"
-            add_changeset(:patch, "Changeset with indenting.\n  - item 1\n  - item 2")
+            add_changeset(:patch, :message => "Changeset with indenting.\n  - item 1\n  - item 2")
           end
           create_package :package_c do
             create_package_mix :version => "1.2.3"

--- a/spec/support/helpers/changeset_helper.rb
+++ b/spec/support/helpers/changeset_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ChangesetHelper
-  def add_changeset(bump, message = nil)
+  def add_changeset(bump, message: nil)
     @changeset_count ||= 0
     @changeset_count += 1
     FileUtils.mkdir_p(".changesets")

--- a/spec/support/helpers/changeset_helper.rb
+++ b/spec/support/helpers/changeset_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ChangesetHelper
-  def add_changeset(bump, message: nil)
+  def add_changeset(bump, type: :add, message: nil)
     @changeset_count ||= 0
     @changeset_count += 1
     FileUtils.mkdir_p(".changesets")
@@ -10,6 +10,7 @@ module ChangesetHelper
       metadata = <<~METADATA
         ---
         bump: #{bump}
+        type: #{type}
         ---
 
       METADATA

--- a/spec/support/helpers/project_helper.rb
+++ b/spec/support/helpers/project_helper.rb
@@ -146,7 +146,7 @@ module ProjectHelper
   def create_changelog
     File.open "CHANGELOG.md", "w" do |file|
       file.write <<~IGNORE
-        # #{current_package} Changelog
+        # #{in_package? ? current_package : "Project"} Changelog
 
         ## 0.0.0
 


### PR DESCRIPTION
## Make add_changeset message arg a keyword argument

This makes it more clear what the optional argument is used for, if
used. Also makes adding more optional arguments in the future easier.

## Add types to changesets

Support different types of changesets:
add, change, fix, deprecate, remove and security.

These different types help communicate to the reader what type of
release a package version is and what types of changes it included.

This adopts the same types of changes as the Keep a Changelog format
described here: https://keepachangelog.com/en/1.0.0/
But doesn't adopt it entirely.

The changeset metadata gets an additional `type` field, used to indicate
the type of change. The naming is not matching the label in the
changelog exactly. I think this short naming is easier to remember when
writing a changeset. People can also use the `mono changeset add` tool
and it will prompt them for the type.

The `ChangesetCollection#write_changesets_to_changelog` method could
probably use a refactor at this point. But my head is not in the right
place for that right now. Also, there previously were no unit tests for
it even, so let's start small.

Closes #31
