### PR TITLE
Validate changesets when parsing

### DIFF
--- a/.changesets/validate-changesets-when-parsing.md
+++ b/.changesets/validate-changesets-when-parsing.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Validate changesets when parsing. With the addition of changeset types, make sure that the changesets have a version bump and type specified and that they are known values. Otherwise, these changesets would not be picked up by mono.


### PR DESCRIPTION
With the addition of changeset types, if an old changeset did not have a
changeset type, it would silently be ignored.

This change validates all changesets when they are parsed, and raises
and error when something invalid is detected. This way we won't ignore
any old changesets.

Old changesets will need to be updated to specify a change type if
published with a more recent mono version.