### PR TITLE
Swap key values for Changeset::SUPPORTED_TYPES

### DIFF
--- a/lib/mono/changeset.rb
+++ b/lib/mono/changeset.rb
@@ -8,12 +8,12 @@ module Mono
 
     # Sorted Hash of supported types in the changelog
     SUPPORTED_TYPES = {
-      "Added" => "add",
-      "Changed" => "change",
-      "Deprecated" => "deprecate",
-      "Removed" => "remove",
-      "Fixed" => "fix",
-      "Security" => "security"
+      "add" => "Added",
+      "change" => "Changed",
+      "deprecate" => "Deprecated",
+      "remove" => "Removed",
+      "fix" => "Fixed",
+      "security" => "Security"
     }.freeze
     # Supported changeset version bumps, sorted by biggest change. The "major"
     # change being the largest, index 0, and patch being the lowest, index 2.
@@ -49,7 +49,7 @@ module Mono
     end
 
     def self.supported_type?(type)
-      SUPPORTED_TYPES.values.include?(type)
+      SUPPORTED_TYPES.include?(type)
     end
 
     def self.parse(file)

--- a/lib/mono/changeset_collection.rb
+++ b/lib/mono/changeset_collection.rb
@@ -29,8 +29,8 @@ module Mono
         new_messages[changeset.type] << build_changelog_entry(changeset)
       end
       content = []
-      Changeset::SUPPORTED_TYPES.each do |label, value|
-        messages_for_type = new_messages[value]
+      Changeset::SUPPORTED_TYPES.each do |key, label|
+        messages_for_type = new_messages[key]
         next if messages_for_type.empty?
 
         content << "\n### #{label}\n\n"

--- a/lib/mono/cli/changeset/add.rb
+++ b/lib/mono/cli/changeset/add.rb
@@ -66,21 +66,18 @@ module Mono
         end
 
         def prompt_for_type
-          types = Mono::Changeset::SUPPORTED_TYPES.keys
+          types = Mono::Changeset::SUPPORTED_TYPES.to_a
           loop do
             puts "What type of change is this: "
 
-            types.each_with_index do |label, index|
+            types.each_with_index do |(_value, label), index|
               puts "#{index + 1}: #{label}"
             end
             type_index = required_input("Select type 1-#{types.length}: ")
             type_index = parse_number(type_index)
             if type_index&.positive?
-              type_key = types[type_index - 1]
-              if type_key
-                type = Mono::Changeset::SUPPORTED_TYPES[type_key]
-                break type if type
-              end
+              type = types[type_index - 1]&.first
+              break type if type
             end
 
             puts "Unknown type selected. Please select a type."

--- a/spec/lib/mono/changeset_collection_spec.rb
+++ b/spec/lib/mono/changeset_collection_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Mono::ChangesetCollection do
   end
 
   describe "#write_changesets_to_changelog" do
-    let(:test_project) { :nodejs_npm_single }
+    let(:test_project) { :elixir_single }
     let(:config) { config_for(test_project) }
     let(:package) { Mono::Languages::Elixir::Package.new("my-package", ".", config) }
     let(:collection) { described_class.new(config, package) }


### PR DESCRIPTION
Turns out it's easier to always use the key used in the changeset as the
key, rather than the display label. As it requires look up with the key
in the changeset more often. It makes the code easier in most changes.
Especially in future changes.

[skip changeset]
[skip review]