### PR TITLE
Print changeset types in publish preview

### DIFF
--- a/.changesets/print-changeset-type-on-publish-preview.md
+++ b/.changesets/print-changeset-type-on-publish-preview.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Print changeset type on publish preview.

--- a/lib/mono/changeset.rb
+++ b/lib/mono/changeset.rb
@@ -101,6 +101,22 @@ module Mono
       @metadata["type"]
     end
 
+    def type_label
+      SUPPORTED_TYPES.fetch(type)
+    end
+
+    # Returns the number equivilant of the change type string. A lower number
+    # is a higher change.
+    # - add == 0
+    # - change == 1
+    # - deprecate == 2
+    # - remove == 3
+    # - fix == 4
+    # - security == 5
+    def type_index
+      SUPPORTED_TYPES.keys.index type
+    end
+
     def bump
       @metadata["bump"]
     end

--- a/lib/mono/changeset_collection.rb
+++ b/lib/mono/changeset_collection.rb
@@ -22,20 +22,24 @@ module Mono
         end
     end
 
+    def changesets_by_types_sorted_by_bump
+      collection = Hash.new { |hash, key| hash[key] = [] }
+      changesets
+        .sort_by { |set| [set.type_index, set.bump_index, set.date] }
+        .each { |changeset| collection[changeset.type] << changeset }
+      collection
+    end
+
     def write_changesets_to_changelog
-      new_messages = Hash.new { |hash, key| hash[key] = [] }
-      sets = changesets.sort_by { |set| [set.bump_index, set.date] }
-      sets.each do |changeset|
-        new_messages[changeset.type] << build_changelog_entry(changeset)
-      end
+      changesets_by_type = changesets_by_types_sorted_by_bump
       content = []
       Changeset::SUPPORTED_TYPES.each do |key, label|
-        messages_for_type = new_messages[key]
+        messages_for_type = changesets_by_type[key]
         next if messages_for_type.empty?
 
         content << "\n### #{label}\n\n"
-        messages_for_type.each do |message|
-          content << message
+        messages_for_type.each do |changeset|
+          content << build_changelog_entry(changeset)
         end
       end
 

--- a/lib/mono/cli/publish.rb
+++ b/lib/mono/cli/publish.rb
@@ -97,18 +97,24 @@ module Mono
 
       def print_package_changesets(package)
         puts "  Changesets:"
-        # Sort by biggest version bump at the top
-        changesets = package.changesets.changesets.sort_by(&:bump_index)
-        changesets.each do |changeset|
-          # Clean up the description from indenting and new lines so the
-          # formatting doesn't break
-          description = changeset.message
-            .gsub(/\n\s+/, " ") # Strip out any indenting in new lines
-            .tr("\n", " ") # Strip out any remaining new lines
-          # Trim long changeset messages
-          description = "#{description[0...100]}..." if description.length > 100
-          puts "  - #{changeset.bump}: #{changeset.path}"
-          puts "      #{description}"
+        # Sort by output the same way as the changelog result
+        changesets_by_type =
+          package.changesets.changesets_by_types_sorted_by_bump
+        changesets_by_type.each do |_, changesets|
+          changesets.each do |changeset|
+            # Clean up the description from indenting and new lines so the
+            # formatting doesn't break
+            description = changeset.message
+              .gsub(/\n\s+/, " ") # Strip out any indenting in new lines
+              .tr("\n", " ") # Strip out any remaining new lines
+            # Trim long changeset messages
+            if description.length > 100
+              description = "#{description[0...100]}..."
+            end
+            puts "  - #{changeset.type_label} - " \
+              "#{changeset.bump}: #{changeset.path}"
+            puts "      #{description}"
+          end
         end
       end
 

--- a/spec/lib/mono/changeset_spec.rb
+++ b/spec/lib/mono/changeset_spec.rb
@@ -153,11 +153,81 @@ RSpec.describe Mono::Changeset do
     end
   end
 
+  describe "#type" do
+    let(:changeset) do
+      described_class.new(
+        ".changesets/1_patch.md",
+        { "bump" => "patch", "type" => type },
+        "Message"
+      )
+    end
+
+    describe "with add" do
+      let(:type) { "add" }
+
+      it "return add" do
+        expect(changeset.type).to eql("add")
+        expect(changeset.type_index).to eql(0)
+        expect(changeset.type_label).to eql("Added")
+      end
+    end
+
+    describe "with change" do
+      let(:type) { "change" }
+
+      it "returns change" do
+        expect(changeset.type).to eql("change")
+        expect(changeset.type_index).to eql(1)
+        expect(changeset.type_label).to eql("Changed")
+      end
+    end
+
+    describe "with deprecate" do
+      let(:type) { "deprecate" }
+
+      it "returns deprecate" do
+        expect(changeset.type).to eql("deprecate")
+        expect(changeset.type_index).to eql(2)
+        expect(changeset.type_label).to eql("Deprecated")
+      end
+    end
+
+    describe "with remove" do
+      let(:type) { "remove" }
+
+      it "returns remove" do
+        expect(changeset.type).to eql("remove")
+        expect(changeset.type_index).to eql(3)
+        expect(changeset.type_label).to eql("Removed")
+      end
+    end
+
+    describe "with fix" do
+      let(:type) { "fix" }
+
+      it "returns fix" do
+        expect(changeset.type).to eql("fix")
+        expect(changeset.type_index).to eql(4)
+        expect(changeset.type_label).to eql("Fixed")
+      end
+    end
+
+    describe "with security" do
+      let(:type) { "security" }
+
+      it "returns security" do
+        expect(changeset.type).to eql("security")
+        expect(changeset.type_index).to eql(5)
+        expect(changeset.type_label).to eql("Security")
+      end
+    end
+  end
+
   describe "#bump" do
     let(:changeset) do
       described_class.new(
         ".changesets/1_patch.md",
-        { "bump" => bump },
+        { "bump" => bump, "type" => "add" },
         "Message"
       )
     end

--- a/spec/lib/mono/cli/publish/base_spec.rb
+++ b/spec/lib/mono/cli/publish/base_spec.rb
@@ -70,9 +70,20 @@ RSpec.describe Mono::Cli::Publish do
       it "prints changeset previews in the package summary" do
         prepare_elixir_project do
           create_package_mix :version => "1.2.3"
-          add_changeset(:patch, :message => "a" * 101) # Limits to 100 characters in preview
-          add_changeset(:major, :message => "This is a major changeset bump.\nLine 2.\nLine 3.")
-          add_changeset(:minor)
+          add_changeset :patch,
+            :type => :change,
+            :message => "a" * 101 # Limits to 100 characters in preview
+          add_changeset :major,
+            :type => :change,
+            :message => "This is a major changeset bump.\nLine 2.\nLine 3."
+          add_changeset :minor, :type => :change
+          add_changeset :patch,
+            :type => :add,
+            :message => "a" * 101 # Limits to 100 characters in preview
+          add_changeset :major,
+            :type => :add,
+            :message => "This is a major changeset bump.\nLine 2.\nLine 3."
+          add_changeset :minor, :type => :add
         end
         do_not_publish_package
         output =
@@ -93,11 +104,17 @@ RSpec.describe Mono::Cli::Publish do
             Current version: v1.2.3
             Next version:    v2.0.0 (major)
             Changesets:
-            - major: ./.changesets/2_major.md
+            - Added - major: ./.changesets/5_major.md
                 This is a major changeset bump. Line 2. Line 3.
-            - minor: ./.changesets/3_minor.md
+            - Added - minor: ./.changesets/6_minor.md
                 This is a minor changeset bump.
-            - patch: ./.changesets/1_patch.md
+            - Added - patch: ./.changesets/4_patch.md
+                #{"a" * 100}...
+            - Changed - major: ./.changesets/2_major.md
+                This is a major changeset bump. Line 2. Line 3.
+            - Changed - minor: ./.changesets/3_minor.md
+                This is a minor changeset bump.
+            - Changed - patch: ./.changesets/1_patch.md
                 #{"a" * 100}...
         OUTPUT
 
@@ -142,17 +159,17 @@ RSpec.describe Mono::Cli::Publish do
             Current version: package_a@1.2.3
             Next version:    package_a@2.0.0 (major)
             Changesets:
-            - major: packages/package_a/.changesets/2_major.md
+            - Added - major: packages/package_a/.changesets/2_major.md
                 This is a major changeset bump. Line 2. Line 3.
-            - minor: packages/package_a/.changesets/3_minor.md
+            - Added - minor: packages/package_a/.changesets/3_minor.md
                 This is a minor changeset bump.
-            - patch: packages/package_a/.changesets/1_patch.md
+            - Added - patch: packages/package_a/.changesets/1_patch.md
                 #{"a" * 100}...
           - package_b:
             Current version: package_b@1.2.3
             Next version:    package_b@1.2.4 (patch)
             Changesets:
-            - patch: packages/package_b/.changesets/4_patch.md
+            - Added - patch: packages/package_b/.changesets/4_patch.md
                 Changeset with indenting. - item 1 - item 2
           - package_c: (Will not publish)
         OUTPUT


### PR DESCRIPTION
When we print the changesets in the `mono publish` command, also print
the changeset types so all the metadata is visible. The order of the
printed output matches the changelog result. The `major` bumps aren't
necessarily always at the top of the preview.