### PR TITLE
Update Git linter (Lintje) to 0.6.1

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -28,8 +28,7 @@ blocks:
     jobs:
     - name: Git Lint (Lintje)
       commands:
-      - script/ci/install_lintje
-      - $HOME/bin/lintje $SEMAPHORE_GIT_COMMIT_RANGE
+      - script/ci/lint_git
 - name: Ruby Linters
   dependencies: []
   task:

--- a/script/ci/lint_git
+++ b/script/ci/lint_git
@@ -2,7 +2,7 @@
 
 set -eu
 
-LINTJE_VERSION=0.3.0
+LINTJE_VERSION=0.6.1
 
 mkdir -p $HOME/bin
 cache_key=v1-lintje-$LINTJE_VERSION
@@ -18,3 +18,5 @@ else
     tar -xz --directory $HOME/bin
   cache store $cache_key $HOME/bin/lintje
 fi
+
+$HOME/bin/lintje $SEMAPHORE_GIT_COMMIT_RANGE


### PR DESCRIPTION
Includes the latest rule updates and has a more human friendly output.

Also update the script filename and contents to match the other
repositories.

[skip changeset]
[skip review]