### PR TITLE
Fix changeset filename generation

### DIFF
--- a/.changesets/fix-changeset-filenames-with-symbols.md
+++ b/.changesets/fix-changeset-filenames-with-symbols.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix publishing with changeset filenames containing unescaped symbols.

--- a/lib/mono/changeset.rb
+++ b/lib/mono/changeset.rb
@@ -137,7 +137,9 @@ module Mono
     def commit
       @commit ||=
         begin
-          git_log = `git log -n 1 --pretty="format:%h %H %cI" -- #{path}`
+          escaped_path = path.gsub('"', '\"')
+          git_log =
+            `git log -n 1 --pretty="format:%h %H %cI" -- "#{escaped_path}"`
           short, long, date = git_log.split(" ")
           {
             :short => short,

--- a/lib/mono/cli/changeset/add.rb
+++ b/lib/mono/cli/changeset/add.rb
@@ -19,7 +19,7 @@ module Mono
           FileUtils.touch(File.join(dir, ".gitkeep"))
           change_description =
             required_input("Summarize the change (for changeset filename): ")
-          filename = change_description.downcase.tr(". /\\", "-")
+          filename = change_description.downcase.tr(".,'\" /\\", "-")
           filepath = File.join(dir, "#{filename}.md")
           type = prompt_for_type
           bump = prompt_for_bump

--- a/spec/lib/mono/changeset_spec.rb
+++ b/spec/lib/mono/changeset_spec.rb
@@ -277,10 +277,28 @@ RSpec.describe Mono::Changeset do
   end
 
   describe "#commit" do
-    it "returns a hash with commit metadat" do
+    it "returns a hash with commit metadata" do
       prepare_project :nodejs_npm_single
       in_project do
         path = add_changeset :patch
+
+        changeset = described_class.parse(path)
+        commit = changeset.commit
+        expect(commit).to match(
+          :date => kind_of(Time),
+          :long => kind_of(String),
+          :short => kind_of(String)
+        )
+        expect(commit[:long].length).to be >= 40
+        expect(commit[:short].length).to be >= 7
+        expect(commit[:short].length).to be < 40
+      end
+    end
+
+    it "returns a hash with commit metadata" do
+      prepare_project :nodejs_npm_single
+      in_project do
+        path = add_changeset :patch, :filename => "Patch, & \"messagé'"
 
         changeset = described_class.parse(path)
         commit = changeset.commit

--- a/spec/lib/mono/cli/changeset/add_spec.rb
+++ b/spec/lib/mono/cli/changeset/add_spec.rb
@@ -178,6 +178,30 @@ RSpec.describe Mono::Cli::Changeset do
         expect(exit_status).to eql(0), output
       end
     end
+
+    context "with special symbols in the description" do
+      it "creates a file with a sanitized filename" do
+        prepare_project :elixir_single
+
+        add_cli_input "My \"Awes/o\\mé', patch"
+        add_cli_input "1" # Type: "add"
+        add_cli_input "patch"
+        add_cli_input "y"
+        output =
+          capture_stdout do
+            in_project { run_changeset_add }
+          end
+
+        changeset_path = ".changesets/my--awes-o-mé---patch.md"
+        expect(output).to include(
+          "Opening ./#{changeset_path} with editor..."
+        )
+        expect(performed_commands).to eql([
+          ["/elixir_single_project", "$EDITOR ./#{changeset_path}"]
+        ])
+        expect(exit_status).to eql(0), output
+      end
+    end
   end
 
   context "with mono repo" do

--- a/spec/support/helpers/changeset_helper.rb
+++ b/spec/support/helpers/changeset_helper.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 module ChangesetHelper
-  def add_changeset(bump, type: :add, message: nil)
+  def add_changeset(bump, type: :add, message: nil, filename: nil)
     @changeset_count ||= 0
     @changeset_count += 1
     FileUtils.mkdir_p(".changesets")
-    path = ".changesets/#{@changeset_count}_#{bump}.md"
+    filename ||= "#{@changeset_count}_#{bump}"
+    path = ".changesets/#{filename}.md"
     unless bump == :none
       metadata = <<~METADATA
         ---


### PR DESCRIPTION
When fetching some metadata from Git for a certain changeset, surround
the filename in quotes and escape any quotes in the filename so that
quotes don't break the Git command.

Also escape a couple more characters during file generation, but this is
extra since people can manually create filenames with whatever
characters they want.

I haven't stripped out all non-`\w` characters, because that would strip
out too many valid characters.

Fixes #36