### PR TITLE
Prevent duplicate dependency changesets

### DIFF
--- a/.changesets/prevent-duplicate-dependency-update-changesets.md
+++ b/.changesets/prevent-duplicate-dependency-update-changesets.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Prevent duplicate dependency bump changesets. Previously, if a package's dependency had a dependency that was also updated, the final package in the tree would track multiple changesets for the same dependency update.

--- a/lib/mono/changeset.rb
+++ b/lib/mono/changeset.rb
@@ -171,4 +171,15 @@ module Mono
       # noop
     end
   end
+
+  class DependencyBumpMemoryChangeset < MemoryChangeset
+    attr_reader :dependency_name
+
+    def initialize(dependency)
+      @dependency_name = dependency.name
+      message = "Update #{dependency.name} dependency to " \
+        "#{dependency.next_version}."
+      super({ "bump" => "patch", "type" => "change" }, message)
+    end
+  end
 end

--- a/lib/mono/package.rb
+++ b/lib/mono/package.rb
@@ -60,14 +60,20 @@ module Mono
       dependencies.key?(package.name)
     end
 
+    def dependency_updated_already?(package)
+      changesets.changesets.any? do |changeset|
+        next unless changeset.respond_to? :dependency_name
+
+        changeset.dependency_name == package.name
+      end
+    end
+
     def update_dependency(package)
       return unless dependency?(package)
+      return if dependency_updated_already?(package)
 
       @updated_dependencies[package.name] = package.next_version.to_s
-      changesets.changesets << MemoryChangeset.new(
-        { "bump" => "patch", "type" => "change" },
-        "Update #{package.name} dependency to #{package.next_version}."
-      )
+      changesets.changesets << DependencyBumpMemoryChangeset.new(package)
     end
 
     # :nocov:


### PR DESCRIPTION
Track which dependencies are updated in a package, and only add another
changeset if it wasn't already updated. There should never be the
scenario that the same package is updated to another type of version
bump, so the message should always be the same.

I created a new `DependencyBumpMemoryChangeset` class to track the types
of in memory changesets that created during this process and to be able
to compare them.

Fixes #25