### PR TITLE
Support package.json devdependencies on publish

### DIFF
--- a/.changesets/support-node-js-devdependencies.md
+++ b/.changesets/support-node-js-devdependencies.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Support Node.js package.json `devDependencies`. Any package in the workspace that's specified as a dev dependency by other packages are also updated upon publish.

--- a/lib/mono/languages/nodejs/package.rb
+++ b/lib/mono/languages/nodejs/package.rb
@@ -43,7 +43,8 @@ module Mono
             begin
               deps = @package_json.fetch("dependencies", {})
               optional_deps = @package_json.fetch("optionalDependencies", {})
-              deps.merge(optional_deps)
+              dev_deps = @package_json.fetch("devDependencies", {})
+              deps.merge(optional_deps).merge(dev_deps)
             end
         end
 

--- a/spec/lib/mono/languages/nodejs/package_spec.rb
+++ b/spec/lib/mono/languages/nodejs/package_spec.rb
@@ -32,13 +32,54 @@ RSpec.describe Mono::Languages::Nodejs::Package do
         )
       end
     end
+
+    context "with optionalDependencies" do
+      it "returns dependencies hash" do
+        package_name = "test_package"
+        create_package_with_dependencies package_name,
+          :dependencies => {
+            "lodash" => "4.17.21"
+          },
+          :optionalDependencies => {
+            "tslib" => "2.2.1"
+          }
+
+        package = package_for_path(package_name)
+        expect(package.dependencies).to eql(
+          "lodash" => "4.17.21",
+          "tslib" => "2.2.1"
+        )
+      end
+    end
+
+    context "with devDependencies" do
+      it "returns dependencies hash" do
+        package_name = "test_package"
+        create_package_with_dependencies package_name,
+          :dependencies => {
+            "lodash" => "4.17.21"
+          },
+          :devDependencies => {
+            "tslib" => "2.2.2"
+          }
+
+        package = package_for_path(package_name)
+        expect(package.dependencies).to eql(
+          "lodash" => "4.17.21",
+          "tslib" => "2.2.2"
+        )
+      end
+    end
   end
 
-  def create_package_with_dependencies(path, version: "1.2.3", dependencies: {})
+  def create_package_with_dependencies(
+    path,
+    version: "1.2.3",
+    **options
+  )
     prepare_new_project do
       create_package path do
-        create_package_json :version => version,
-          :dependencies => dependencies
+        create_package_json({ :version => version }.merge(options))
       end
     end
   end


### PR DESCRIPTION
When I published the JavaScript packages I noticed the
`@appsignal/types` package had to versions in `yarn.lock`.
This was because the package was specified in the `devdependencies` of
the `@appsignal/plugin-breadcrumbs-console` package. Mono only checked
the `dependencies` and `optionalDependencies`, so the package version
was not updated.

This was not really a problem because it's only used during development
and testing, but it's not good to not update the package version and
possibly keep testing against an older version.

This change will update any package in the workspace listed in
`devdependencies` upon `mono publish`.