### PR TITLE
Strip out colon symbols from filenames

### DIFF
--- a/.changesets/strip-out-colons-from-changeset-filenames.md
+++ b/.changesets/strip-out-colons-from-changeset-filenames.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Strip out colons from changeset filenames. The colon and semicolon symbols are now replaced with a dash symbol.

--- a/lib/mono/cli/changeset/add.rb
+++ b/lib/mono/cli/changeset/add.rb
@@ -19,7 +19,7 @@ module Mono
           FileUtils.touch(File.join(dir, ".gitkeep"))
           change_description =
             required_input("Summarize the change (for changeset filename): ")
-          filename = change_description.downcase.tr(".,'\" /\\", "-")
+          filename = change_description.downcase.tr(":;.,'\" /\\", "-")
           filepath = File.join(dir, "#{filename}.md")
           type = prompt_for_type
           bump = prompt_for_bump

--- a/spec/lib/mono/cli/changeset/add_spec.rb
+++ b/spec/lib/mono/cli/changeset/add_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Mono::Cli::Changeset do
       it "creates the .changeset directory and a changeset file" do
         prepare_project :elixir_single
 
-        add_cli_input "My Awes/o\\me pa.tch"
+        add_cli_input "My:; Awes/o\\me pa.tch"
         add_cli_input "1"
         add_cli_input "patch"
         add_cli_input "n"
@@ -19,7 +19,7 @@ RSpec.describe Mono::Cli::Changeset do
             in_project { run_changeset_add }
           end
 
-        changeset_path = ".changesets/my-awes-o-me-pa-tch.md"
+        changeset_path = ".changesets/my---awes-o-me-pa-tch.md"
         expect(output).to include(
           "Summarize the change (for changeset filename):",
           "What type of semver bump is this (major/minor/patch): ",
@@ -35,7 +35,7 @@ RSpec.describe Mono::Cli::Changeset do
             type: "add"
             ---
 
-            My Awes/o\\me pa.tch
+            My:; Awes/o\\me pa.tch
           CHANGESET
         end
         expect(performed_commands).to eql([])


### PR DESCRIPTION
Sanitize the changeset filenames further by stripping out these symbols.
Avoids issues with fetching metadata from Git when specifying a path.