### PR TITLE
Support custom tags for Node.js package releases

### DIFF
--- a/.changesets/support-custom-tags-for-node-js-packages.md
+++ b/.changesets/support-custom-tags-for-node-js-packages.md
@@ -1,0 +1,10 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Support custom tags for Node.js packages. Call `mono publish` with the `--tag` option to set custom tags for new releases. By default Node.js adds the `latest` tag to new releases, but this may not always be desired. The tag specified applies to all packages published by mono. The `--tag` option has precedence over the `--prerelease` option.
+
+```
+mono publish --tag 2.x-stable
+```

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,6 +81,12 @@ Metrics/ClassLength:
 Metrics/AbcSize:
   Enabled: false
 
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
 Naming/RescuedExceptionsVariableName:
   Enabled: false
 

--- a/lib/mono/cli.rb
+++ b/lib/mono/cli.rb
@@ -116,7 +116,7 @@ module Mono
         execute_command
       end
 
-      def execute_command # rubocop:disable Metrics/CyclomaticComplexity
+      def execute_command
         command = @options.shift
         case command
         when "init"

--- a/lib/mono/cli.rb
+++ b/lib/mono/cli.rb
@@ -281,6 +281,10 @@ module Mono
           opts.on "--rc", "Release a rc prerelease" do
             params[:prerelease] = "rc"
           end
+          opts.on "--tag TAG",
+            "Set the tag for the package release (Node.js only)" do |tag|
+            params[:tag] = tag
+          end
         end.parse(@options)
         params
       end

--- a/lib/mono/cli/publish.rb
+++ b/lib/mono/cli/publish.rb
@@ -3,23 +3,24 @@
 module Mono
   module Cli
     class Publish < Base
-      attr_reader :prerelease
+      attr_reader :prerelease, :tag
       alias prerelease? prerelease
+      alias tag? tag
 
       def initialize(options = {})
         @prerelease = options[:prerelease]
+        @tag = options[:tag]
         super(options)
       end
 
       def execute
         exit_cli "No packages found in this directory!" unless packages.any?
 
-        if prerelease?
+        packages.each do |package|
           # Tell to-be-published packages that they should update to a
           # prerelease
-          packages.each do |package|
-            package.prerelease = prerelease
-          end
+          package.prerelease = prerelease if prerelease?
+          package.tag = tag if tag?
         end
 
         changed_packages = package_promoter.changed_packages

--- a/lib/mono/cli/publish.rb
+++ b/lib/mono/cli/publish.rb
@@ -14,6 +14,12 @@ module Mono
       end
 
       def execute
+        if prerelease? && tag?
+          exit_cli "Error: Both a prerelease flag (--alpha, --beta, --rc) " \
+            "and --tag options are set. Only one can be used at a time to " \
+            "tag a release. Exiting."
+        end
+
         exit_cli "No packages found in this directory!" unless packages.any?
 
         packages.each do |package|

--- a/lib/mono/dependency_tree.rb
+++ b/lib/mono/dependency_tree.rb
@@ -65,7 +65,7 @@ module Mono
     # Build a dependency tree. Track which packages depend on other packages in
     # this project. It creates a tree with dependencies going both ways:
     # dependencies and dependents.
-    def build # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def build
       @tree =
         Hash.new do |hash, key|
           hash[key] = {

--- a/lib/mono/languages/nodejs/package.rb
+++ b/lib/mono/languages/nodejs/package.rb
@@ -54,7 +54,9 @@ module Mono
 
         def publish_package
           options = []
-          if next_version.prerelease?
+          if tag?
+            options << "--tag #{tag}"
+          elsif next_version.prerelease?
             options << "--tag #{next_version.prerelease_type}"
           end
           options << "--new-version #{next_version}" if npm_client == "yarn"

--- a/lib/mono/package.rb
+++ b/lib/mono/package.rb
@@ -18,7 +18,8 @@ module Mono
     include Command::Helper
 
     attr_reader :path, :name
-    attr_accessor :prerelease
+    attr_accessor :prerelease, :tag
+    alias tag? tag
 
     def initialize(name, path, config)
       @path = path

--- a/lib/mono/package_promoter.rb
+++ b/lib/mono/package_promoter.rb
@@ -12,7 +12,7 @@ module Mono
 
     # Find packages that will be updated, and update packages that depend on
     # those packages to use the updated version of that package.
-    def changed_packages # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def changed_packages
       @changed_packages ||=
         begin
           # Track which packages have registered changes and require an update

--- a/spec/lib/mono/cli/publish/base_spec.rb
+++ b/spec/lib/mono/cli/publish/base_spec.rb
@@ -550,6 +550,31 @@ RSpec.describe Mono::Cli::Publish do
     end
   end
 
+  context "with a prerelease flag and tag option" do
+    it "exits with an error" do
+      prepare_new_project do
+        create_mono_config "language" => "ruby"
+        create_ruby_package_files :name => "package_a", :version => "1.2.3"
+      end
+      confirm_publish_package
+      output =
+        capture_stdout do
+          in_project do
+            perform_commands do
+              run_publish(["--alpha", "--tag", "beta"])
+            end
+          end
+        end
+
+      expect(output).to include(
+        "Mono::Error: Error: Both a prerelease flag (--alpha, --beta, --rc) and " \
+          "--tag options are set."
+      )
+      expect(performed_commands).to eql([])
+      expect(exit_status).to eql(1), output
+    end
+  end
+
   context "with hooks" do
     it "runs hooks around command" do
       prepare_project :ruby_single


### PR DESCRIPTION
We want to release versions of the Node.js packages that shouldn't receive the `latest` tag on publish, which Node.js does automatically.

Add the `--tag` option to set a custom tag for releases to avoid it receiving the `latest` tag.

Unblocks https://github.com/appsignal/appsignal-nodejs/issues/869