### PR TITLE
Update RuboCop and fix issues

### DIFF
--- a/.changesets/update-to-ruby-3.md
+++ b/.changesets/update-to-ruby-3.md
@@ -1,0 +1,6 @@
+---
+bump: "minor"
+type: "change"
+---
+
+Require Ruby 3 going forward.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ AllCops:
   UseCache: true
   CacheRootDirectory: ./tmp
   NewCops: enable
+  TargetRubyVersion: 3.0
 
 Style/SpecialGlobalVars:
   Enabled: false
@@ -68,6 +69,9 @@ Layout/FirstArrayElementIndentation:
 
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
+
+Layout/LineEndStringConcatenationIndentation:
+  EnforcedStyle: indented
 
 Layout/LineLength:
   Max: 80

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 group :development do
-  gem "rubocop", "1.16.0"
+  gem "rubocop", "1.50.2"
   gem "simplecov"
 end
 

--- a/lib/mono/changeset.rb
+++ b/lib/mono/changeset.rb
@@ -19,7 +19,7 @@ module Mono
     # change being the largest, index 0, and patch being the lowest, index 2.
     SUPPORTED_BUMPS = %w[major minor patch].freeze
     YAML_FRONT_MATTER_REGEXP =
-      /\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)/m.freeze
+      /\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)/m
 
     class MetadataError < Mono::Error; end
 
@@ -77,7 +77,7 @@ module Mono
       if message.strip.empty?
         raise EmptyMessageError,
           "No changeset message found for changeset: `#{file}`. " \
-          "Please add a description of the change."
+            "Please add a description of the change."
       end
       new(file, metadata, message)
     end
@@ -93,7 +93,7 @@ module Mono
       unless SUPPORTED_BUMPS.include?(@metadata["bump"])
         raise UnknownBumpTypeError,
           "Unknown bump type specified for changeset: `#{path}`. " \
-          "Please specify either major, minor or patch."
+            "Please specify either major, minor or patch."
       end
     end
 

--- a/lib/mono/changeset_collection.rb
+++ b/lib/mono/changeset_collection.rb
@@ -48,16 +48,14 @@ module Mono
       contents = File.read(changelog_path)
       lines = contents.lines # Keep original contents to add to the bottom
       heading = lines.shift # Keep original heading
-      File.open(changelog_path, "w+") do |file|
-        file.write(<<~CHANGELOG)
-          #{heading}
-          ## #{package.next_version}
+      File.write(changelog_path, <<~CHANGELOG)
+        #{heading}
+        ## #{package.next_version}
 
-          #{content.join.strip}
+        #{content.join.strip}
 
-          #{lines.join.strip}
-        CHANGELOG
-      end
+        #{lines.join.strip}
+      CHANGELOG
       changesets.each(&:remove)
     end
 

--- a/lib/mono/cli/changeset/add.rb
+++ b/lib/mono/cli/changeset/add.rb
@@ -24,16 +24,14 @@ module Mono
           type = prompt_for_type
           bump = prompt_for_bump
 
-          File.open(filepath, "w+") do |file|
-            file.write(<<~CONTENTS)
-              ---
-              bump: "#{bump}"
-              type: "#{type}"
-              ---
+          File.write(filepath, <<~CONTENTS)
+            ---
+            bump: "#{bump}"
+            type: "#{type}"
+            ---
 
-              #{change_description}
-            CONTENTS
-          end
+            #{change_description}
+          CONTENTS
           puts "Changeset file created at #{filepath}"
           open_editor = yes_or_no(
             "Do you want to open this file to add more information? (y/N): ",
@@ -86,8 +84,9 @@ module Mono
 
         def prompt_for_bump
           loop do
-            input = required_input \
+            input = required_input(
               "What type of semver bump is this (major/minor/patch): "
+            )
             if Mono::Changeset.supported_bump?(input)
               break input
             else

--- a/lib/mono/cli/init.rb
+++ b/lib/mono/cli/init.rb
@@ -27,9 +27,7 @@ module Mono
           config["packages_dir"] = packages_dir
         end
         puts "Writing config file."
-        File.open(File.join(Dir.pwd, "mono.yml"), "w+") do |file|
-          file.write YAML.dump(config)
-        end
+        File.write(File.join(Dir.pwd, "mono.yml"), YAML.dump(config))
         puts "Mono config file created!"
         puts "Please see the mono project README for additional config options."
       end

--- a/lib/mono/cli/publish.rb
+++ b/lib/mono/cli/publish.rb
@@ -153,9 +153,9 @@ module Mono
           end.join("\n")
         run_command "git add -A"
         run_command "git commit " \
-                    "-m 'Publish packages' " \
-                    "-m '#{packages_list}' " \
-                    "-m '[ci skip]'"
+          "-m 'Publish packages' " \
+          "-m '#{packages_list}' " \
+          "-m '[ci skip]'"
 
         packages.each do |package|
           puts "## Tag package #{package.next_tag}"

--- a/lib/mono/languages/elixir/package.rb
+++ b/lib/mono/languages/elixir/package.rb
@@ -29,9 +29,7 @@ module Mono
           contents = read_mix_exs
           new_contents =
             contents.sub(VERSION_REGEX, "\\1 \"#{next_version}\"\\3")
-          File.open(mix_exs_path, "w+") do |file|
-            file.write new_contents
-          end
+          File.write(mix_exs_path, new_contents)
         end
 
         def bootstrap_package(_options = {})
@@ -60,8 +58,8 @@ module Mono
 
         private
 
-        VERSION_REGEX = /(@version|version:) "(.*)"(,?)$/.freeze
-        DEPENDENCY_REGEX = /^\s*{:(.*), "(.*)"}/.freeze
+        VERSION_REGEX = /(@version|version:) "(.*)"(,?)$/
+        DEPENDENCY_REGEX = /^\s*{:(.*), "(.*)"}/
 
         def read_mix_exs
           File.read(mix_exs_path)

--- a/lib/mono/languages/nodejs/package.rb
+++ b/lib/mono/languages/nodejs/package.rb
@@ -33,9 +33,7 @@ module Mono
                 %("#{dep}": "=#{version}")
               )
           end
-          File.open(package_json_path, "w+") do |file|
-            file.write contents
-          end
+          File.write(package_json_path, contents)
         end
 
         def dependencies
@@ -88,7 +86,7 @@ module Mono
 
         private
 
-        VERSION_REGEX = /"version": "(.*)"/.freeze
+        VERSION_REGEX = /"version": "(.*)"/
 
         def read_package_json
           File.read(package_json_path)

--- a/lib/mono/languages/ruby/package.rb
+++ b/lib/mono/languages/ruby/package.rb
@@ -31,9 +31,7 @@ module Mono
           contents = read_version
           new_contents =
             contents.sub(VERSION_REGEX, %(VERSION = "#{next_version}"))
-          File.open(version_path, "w+") do |file|
-            file.write new_contents
-          end
+          File.write(version_path, new_contents)
 
           return unless spec_path
 
@@ -43,9 +41,7 @@ module Mono
               contents.sub(/.add_dependency (["'].*["']), (["'])(.*)["']/,
                 ".add_dependency \\1, \\2#{version}\\2")
           end
-          File.open(spec_path, "w+") do |file|
-            file.write contents
-          end
+          File.write(spec_path, contents)
         end
 
         def bootstrap_package(_options = {})
@@ -89,8 +85,8 @@ module Mono
 
         private
 
-        VERSION_REGEX = /VERSION = "(.*)"/.freeze
-        DEPENDENCY_REGEX = /.*.add_dependency ["'](.*)["'], ["'](.*)["']/.freeze
+        VERSION_REGEX = /VERSION = "(.*)"/
+        DEPENDENCY_REGEX = /.*.add_dependency ["'](.*)["'], ["'](.*)["']/
 
         def read_version
           File.read(version_path)

--- a/script/ci/ruby_prologue
+++ b/script/ci/ruby_prologue
@@ -2,7 +2,7 @@
 
 set -e
 
-sem-version ruby 2.7.3
+sem-version ruby 3.2.2
 sem-version erlang 23.3
 sem-version elixir 1.11.3
 

--- a/spec/lib/mono/cli/publish/nodejs_spec.rb
+++ b/spec/lib/mono/cli/publish/nodejs_spec.rb
@@ -425,7 +425,7 @@ RSpec.describe Mono::Cli::Publish do
       it "publishes the updated package with build artifacts" do
         prepare_nodejs_project "packages_dir" => "packages/" do
           create_package :package_a do
-            File.open("constants.js", "w") { |file| file.write("000") }
+            File.write("constants.js", "000")
             create_package_json :version => "1.0.0",
               :scripts => {
                 :prebuild => "echo 123 > constants.js"

--- a/spec/support/helpers/changeset_helper.rb
+++ b/spec/support/helpers/changeset_helper.rb
@@ -17,9 +17,7 @@ module ChangesetHelper
       METADATA
     end
     message ||= "This is a #{bump} changeset bump."
-    File.open(path, "w+") do |file|
-      file.write("#{metadata}#{message}")
-    end
+    File.write(path, "#{metadata}#{message}")
     commit_changeset("Changeset #{@changeset_count} #{bump}")
     path
   end

--- a/spec/support/helpers/project_helper.rb
+++ b/spec/support/helpers/project_helper.rb
@@ -84,26 +84,24 @@ module ProjectHelper
   def init_project
     in_project do
       git_init_directory
-      File.open ".gitignore", "w" do |file|
-        file.write <<~IGNORE
-          # Multiple languages
-          *.lock
-          tmp
+      File.write(".gitignore", <<~IGNORE)
+        # Multiple languages
+        *.lock
+        tmp
 
-          # Ruby
-          *.gem
-          .bundle
-          vendor
+        # Ruby
+        *.gem
+        .bundle
+        vendor
 
-          # Node.js
-          package-lock.json
-          node_modules/
+        # Node.js
+        package-lock.json
+        node_modules/
 
-          # Elixir
-          deps
-          _build
-        IGNORE
-      end
+        # Elixir
+        deps
+        _build
+      IGNORE
       commit_changes "Initial commit"
     end
   end
@@ -144,17 +142,15 @@ module ProjectHelper
   end
 
   def create_changelog
-    File.open "CHANGELOG.md", "w" do |file|
-      file.write <<~IGNORE
-        # #{in_package? ? current_package : "Project"} Changelog
+    File.write("CHANGELOG.md", <<~IGNORE)
+      # #{in_package? ? current_package : "Project"} Changelog
 
-        ## 0.0.0
+      ## 0.0.0
 
-        - Change 1
-        - Change 2
-        - Change 3
-      IGNORE
-    end
+      - Change 1
+      - Change 2
+      - Change 3
+    IGNORE
   end
 
   def create_package_json(custom_config)
@@ -327,9 +323,7 @@ module ProjectHelper
 
   def update_config(new_config)
     config_file = File.join(ROOT_DIR, EXAMPLES_TMP_DIR, current_project, "mono.yml")
-    File.open(config_file, "w") do |file|
-      file.write(YAML.dump(new_config))
-    end
+    File.write(config_file, YAML.dump(new_config))
   end
 
   def package_for(package, config)
@@ -344,8 +338,6 @@ module ProjectHelper
 
   def update_package_json(new_config)
     package_json = File.join(Dir.pwd, "package.json")
-    File.open(package_json, "w") do |file|
-      file.write(JSON.dump(new_config))
-    end
+    File.write(package_json, JSON.dump(new_config))
   end
 end


### PR DESCRIPTION
Not sure why, but locally it gave me a bunch of errors on Ruby 3. Update RuboCop to fix it and be up-to-date with the latest style.

This assumes Ruby 3 going forward, like our Ruby gem and other projects now also requires. 