### PR TITLE
Omit ci skip tag from publish commit

### DIFF
--- a/.changesets/remove-skip-ci-tag-from-publish-commit.md
+++ b/.changesets/remove-skip-ci-tag-from-publish-commit.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Remove [ci skip] tag from publish commit. Run the CI build for the publish commit just in case anything could break with updating the version.

--- a/lib/mono/cli/publish.rb
+++ b/lib/mono/cli/publish.rb
@@ -154,8 +154,7 @@ module Mono
         run_command "git add -A"
         run_command "git commit " \
           "-m 'Publish packages' " \
-          "-m '#{packages_list}' " \
-          "-m '[ci skip]'"
+          "-m '#{packages_list}'"
 
         packages.each do |package|
           puts "## Tag package #{package.next_tag}"

--- a/spec/lib/mono/cli/publish/base_spec.rb
+++ b/spec/lib/mono/cli/publish/base_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe Mono::Cli::Publish do
       expect(performed_commands).to eql([
         [project_dir, "gem build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}' -m '[ci skip]'"],
+        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "gem push ruby_single_project-#{next_version}.gem"],
         [project_dir, "git push origin main v#{next_version}"]
@@ -336,7 +336,7 @@ RSpec.describe Mono::Cli::Publish do
       expect(performed_commands).to eql([
         [project_dir, "gem build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}' -m '[ci skip]'"],
+        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "gem push ruby_single_project-#{next_version}.gem"],
         [project_dir, "git push origin main v#{next_version}"]
@@ -397,7 +397,7 @@ RSpec.describe Mono::Cli::Publish do
       expect(performed_commands).to eql([
         [project_dir, "gem build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}' -m '[ci skip]'"],
+        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "gem push package_a-#{next_version}.gem"],
         [project_dir, "git push origin main v#{next_version}"]
@@ -460,7 +460,7 @@ RSpec.describe Mono::Cli::Publish do
       expect(performed_commands).to eql([
         [project_dir, "gem build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}' -m '[ci skip]'"],
+        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "gem push package_a-#{next_version}.gem"],
         [project_dir, "git push origin main v#{next_version}"]
@@ -519,7 +519,7 @@ RSpec.describe Mono::Cli::Publish do
       expect(performed_commands).to eql([
         [project_dir, "gem build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}' -m '[ci skip]'"],
+        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "gem push package_a-#{next_version}.gem"],
         [project_dir, "git push origin main v#{next_version}"]
@@ -603,7 +603,7 @@ RSpec.describe Mono::Cli::Publish do
         [project_dir, "gem build"],
         [project_dir, "echo after build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}' -m '[ci skip]'"],
+        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "echo before publish"],
         [project_dir, "gem push ruby_single_project-#{next_version}.gem"],
@@ -648,7 +648,7 @@ RSpec.describe Mono::Cli::Publish do
         [package_two_dir, "mix deps.get"],
         [package_one_dir, "mix compile"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- #{tag}' -m '[ci skip]'"],
+        [project_dir, "git commit -m 'Publish packages' -m '- #{tag}'"],
         [project_dir, "git tag #{tag}"],
         [package_one_dir, "mix hex.publish package --yes"],
         [project_dir, "git push origin main #{tag}"]
@@ -693,7 +693,7 @@ RSpec.describe Mono::Cli::Publish do
         [package_one_dir, "mix compile"],
         [package_two_dir, "mix compile"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- #{tag1}\n- #{tag2}' -m '[ci skip]'"],
+        [project_dir, "git commit -m 'Publish packages' -m '- #{tag1}\n- #{tag2}'"],
         [project_dir, "git tag #{tag1}"],
         [project_dir, "git tag #{tag2}"],
         [package_one_dir, "mix hex.publish package --yes"],

--- a/spec/lib/mono/cli/publish/custom_spec.rb
+++ b/spec/lib/mono/cli/publish/custom_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Mono::Cli::Publish do
       [project_dir, "ruby write_version_file.rb #{next_version}"],
       [project_dir, "echo build"],
       [project_dir, "git add -A"],
-      [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}' -m '[ci skip]'"],
+      [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
       [project_dir, "git tag v#{next_version}"],
       [project_dir, "echo publish"],
       [project_dir, "git push origin main v#{next_version}"]

--- a/spec/lib/mono/cli/publish/elixir_spec.rb
+++ b/spec/lib/mono/cli/publish/elixir_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Mono::Cli::Publish do
         [project_dir, "mix deps.get"],
         [project_dir, "mix compile"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}' -m '[ci skip]'"],
+        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "mix hex.publish package --yes"],
         [project_dir, "git push origin main v#{next_version}"]
@@ -104,7 +104,7 @@ RSpec.describe Mono::Cli::Publish do
         [project_dir, "mix deps.get"],
         [project_dir, "mix compile"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}' -m '[ci skip]'"],
+        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "mix hex.publish package --yes"],
         [project_dir, "git push origin main v#{next_version}"]
@@ -140,7 +140,7 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "mix deps.get"],
           [project_dir, "mix compile"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}' -m '[ci skip]'"],
+          [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
           [project_dir, "git tag v#{next_version}"],
           [project_dir, "mix hex.publish package --yes"]
         ])
@@ -206,7 +206,7 @@ RSpec.describe Mono::Cli::Publish do
         [package_dir_b, "mix deps.get"],
         [package_dir_a, "mix compile"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- #{tag}' -m '[ci skip]'"],
+        [project_dir, "git commit -m 'Publish packages' -m '- #{tag}'"],
         [project_dir, "git tag #{tag}"],
         [package_dir_a, "mix hex.publish package --yes"],
         [project_dir, "git push origin main #{tag}"]
@@ -291,7 +291,7 @@ RSpec.describe Mono::Cli::Publish do
         [package_dir_b, "mix compile"],
         [project_dir, "git add -A"],
         [project_dir,
-         "git commit -m 'Publish packages' -m '- #{tag_a}\n- #{tag_b}' -m '[ci skip]'"],
+         "git commit -m 'Publish packages' -m '- #{tag_a}\n- #{tag_b}'"],
         [project_dir, "git tag #{tag_a}"],
         [project_dir, "git tag #{tag_b}"],
         [package_dir_a, "mix hex.publish package --yes"],

--- a/spec/lib/mono/cli/publish/nodejs_spec.rb
+++ b/spec/lib/mono/cli/publish/nodejs_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm link"],
           [project_dir, "npm run build"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}' -m '[ci skip]'"],
+          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}'"],
           [project_dir, "git tag #{tag}"],
           [project_dir, "npm publish"],
           [project_dir, "git push origin main #{tag}"]
@@ -94,7 +94,7 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm link"],
           [project_dir, "npm run build"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}' -m '[ci skip]'"],
+          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}'"],
           [project_dir, "git tag #{tag}"],
           [project_dir, "npm publish --tag alpha"],
           [project_dir, "git push origin main #{tag}"]
@@ -136,7 +136,7 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm link"],
           [project_dir, "npm run build"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}' -m '[ci skip]'"],
+          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}'"],
           [project_dir, "git tag #{tag}"],
           [project_dir, "npm publish --tag beta"],
           [project_dir, "git push origin main #{tag}"]
@@ -179,7 +179,7 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm link"],
           [project_dir, "npm run build"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}' -m '[ci skip]'"],
+          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}'"],
           [project_dir, "git tag #{tag}"],
           [project_dir, "npm publish --tag #{package_tag}"],
           [project_dir, "git push origin main #{tag}"]
@@ -221,7 +221,7 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm link"],
           [project_dir, "npm run build"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}' -m '[ci skip]'"],
+          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}'"],
           [project_dir, "git tag #{tag}"],
           [project_dir, "npm publish --tag rc"],
           [project_dir, "git push origin main #{tag}"]
@@ -259,7 +259,7 @@ RSpec.describe Mono::Cli::Publish do
             [project_dir, "npm run build"],
             [project_dir, "git add -A"],
             [project_dir,
-             "git commit -m 'Publish packages' -m '- v#{next_version}' -m '[ci skip]'"],
+             "git commit -m 'Publish packages' -m '- v#{next_version}'"],
             [project_dir, "git tag v#{next_version}"],
             [project_dir, "npm publish"]
           ])
@@ -325,7 +325,7 @@ RSpec.describe Mono::Cli::Publish do
           [package_two_dir, "npm link"],
           [project_dir, "npm run build --workspace=package_one"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}' -m '[ci skip]'"],
+          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}'"],
           [project_dir, "git tag #{tag}"],
           [package_one_dir, "npm publish"],
           [project_dir, "git push origin main #{tag}"]
@@ -412,7 +412,7 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm run build --workspace=package_one"],
           [project_dir, "npm run build --workspace=package_two"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '#{commit_message}' -m '[ci skip]'"],
+          [project_dir, "git commit -m 'Publish packages' -m '#{commit_message}'"],
           [project_dir, "git tag #{package_one_tag}"],
           [project_dir, "git tag #{package_two_tag}"],
           [package_one_dir, "npm publish"],
@@ -568,7 +568,7 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm run build --workspace=package_b"],
           [project_dir, "npm run build --workspace=package_c"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '#{commit_message}' -m '[ci skip]'"],
+          [project_dir, "git commit -m 'Publish packages' -m '#{commit_message}'"],
           [project_dir, "git tag #{package_tag_a}"],
           [project_dir, "git tag #{package_tag_b}"],
           [project_dir, "git tag #{package_tag_c}"],
@@ -659,7 +659,7 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm run build --workspace=package_a"],
           [project_dir, "npm run build --workspace=package_b"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '#{commit_message}' -m '[ci skip]'"],
+          [project_dir, "git commit -m 'Publish packages' -m '#{commit_message}'"],
           [project_dir, "git tag #{package_tag_a}"],
           [project_dir, "git tag #{package_tag_b}"],
           [package_dir_a, "npm publish --tag alpha"],
@@ -750,7 +750,7 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm run build --workspace=package_a"],
           [project_dir, "npm run build --workspace=package_b"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '#{commit_message}' -m '[ci skip]'"],
+          [project_dir, "git commit -m 'Publish packages' -m '#{commit_message}'"],
           [project_dir, "git tag #{package_tag_a}"],
           [project_dir, "git tag #{package_tag_b}"],
           [package_dir_a, "npm publish"],
@@ -809,7 +809,7 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "yarn link"],
           [project_dir, "yarn run build"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}' -m '[ci skip]'"],
+          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}'"],
           [project_dir, "git tag #{tag}"],
           [project_dir, "yarn publish --new-version #{next_version}"],
           [project_dir, "git push origin main #{tag}"]

--- a/spec/lib/mono/cli/publish/ruby_spec.rb
+++ b/spec/lib/mono/cli/publish/ruby_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Mono::Cli::Publish do
       expect(performed_commands).to eql([
         [project_dir, "gem build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}' -m '[ci skip]'"],
+        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "gem push mygem-#{next_version}.gem"],
         [project_dir, "git push origin main v#{next_version}"]
@@ -103,7 +103,7 @@ RSpec.describe Mono::Cli::Publish do
         expect(performed_commands).to eql([
           [project_dir, "gem build"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}' -m '[ci skip]'"],
+          [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
           [project_dir, "git tag v#{next_version}"],
           [project_dir, "gem push mygem-#{next_version}.gem"],
           [project_dir, "gem push mygem-#{next_version}-java.gem"],
@@ -159,7 +159,7 @@ RSpec.describe Mono::Cli::Publish do
       expect(performed_commands).to eql([
         [project_dir, "echo build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}' -m '[ci skip]'"],
+        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "echo push"],
         [project_dir, "git push origin main v#{next_version}"]
@@ -194,7 +194,7 @@ RSpec.describe Mono::Cli::Publish do
         expect(performed_commands).to eql([
           [project_dir, "gem build"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}' -m '[ci skip]'"],
+          [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
           [project_dir, "git tag v#{next_version}"],
           [project_dir, "gem push mygem-#{next_version}.gem"]
         ])
@@ -257,7 +257,7 @@ RSpec.describe Mono::Cli::Publish do
       expect(performed_commands).to eql([
         [package_dir_a, "gem build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- #{tag_a}' -m '[ci skip]'"],
+        [project_dir, "git commit -m 'Publish packages' -m '- #{tag_a}'"],
         [project_dir, "git tag #{tag_a}"],
         [project_dir, "gem push packages/package_a/package_a-#{next_version_a}.gem"],
         [project_dir, "git push origin main #{tag_a}"]
@@ -341,7 +341,7 @@ RSpec.describe Mono::Cli::Publish do
         [package_dir_b, "gem build"],
         [project_dir, "git add -A"],
         [project_dir,
-         "git commit -m 'Publish packages' -m '- #{tag_a}\n- #{tag_b}' -m '[ci skip]'"],
+         "git commit -m 'Publish packages' -m '- #{tag_a}\n- #{tag_b}'"],
         [project_dir, "git tag #{tag_a}"],
         [project_dir, "git tag #{tag_b}"],
         [project_dir, "gem push packages/package_a/package_a-#{next_version_a}.gem"],
@@ -455,7 +455,7 @@ RSpec.describe Mono::Cli::Publish do
         [package_dir_b, "gem build"],
         [package_dir_c, "gem build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '#{message}' -m '[ci skip]'"],
+        [project_dir, "git commit -m 'Publish packages' -m '#{message}'"],
         [project_dir, "git tag #{tag_a}"],
         [project_dir, "git tag #{tag_b}"],
         [project_dir, "git tag #{tag_c}"],


### PR DESCRIPTION
Run the build to make sure the published release also works and shows a checkmark for the build on the CI on the latest published commit.

Closes #51