### PR TITLE
Improve publish commit message

### DIFF
--- a/.changesets/improve-publish-commit-message.md
+++ b/.changesets/improve-publish-commit-message.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Improve publish commit message. When only one package is publish, show the version number in the commit subject. Add a small description to the message what was changed.

--- a/lib/mono/cli/publish.rb
+++ b/lib/mono/cli/publish.rb
@@ -147,14 +147,21 @@ module Mono
         run_hooks("git-commit", "pre")
         puts "# Publishing to git"
         puts "## Creating release commit"
-        packages_list =
-          packages.map do |package|
-            "- #{package.next_tag}"
-          end.join("\n")
+        standard_message =
+          "Update version number and CHANGELOG.md."
+        commit_subject, commit_message =
+          if packages.length > 1
+            message =
+              packages.map do |package|
+                "- #{package.next_tag}"
+              end.join("\n")
+            ["Publish packages", "#{standard_message}\n\n#{message}"]
+          else
+            only_package = packages.first
+            ["Publish package #{only_package.next_tag}", standard_message]
+          end
         run_command "git add -A"
-        run_command "git commit " \
-          "-m 'Publish packages' " \
-          "-m '#{packages_list}'"
+        run_command "git commit -m '#{commit_subject}' -m '#{commit_message}'"
 
         packages.each do |package|
           puts "## Tag package #{package.next_tag}"

--- a/spec/lib/mono/cli/publish/base_spec.rb
+++ b/spec/lib/mono/cli/publish/base_spec.rb
@@ -275,7 +275,11 @@ RSpec.describe Mono::Cli::Publish do
       expect(performed_commands).to eql([
         [project_dir, "gem build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
+        [
+          project_dir,
+          "git commit -m 'Publish package v#{next_version}' " \
+            "-m 'Update version number and CHANGELOG.md.'"
+        ],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "gem push ruby_single_project-#{next_version}.gem"],
         [project_dir, "git push origin main v#{next_version}"]
@@ -336,7 +340,11 @@ RSpec.describe Mono::Cli::Publish do
       expect(performed_commands).to eql([
         [project_dir, "gem build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
+        [
+          project_dir,
+          "git commit -m 'Publish package v#{next_version}' " \
+            "-m 'Update version number and CHANGELOG.md.'"
+        ],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "gem push ruby_single_project-#{next_version}.gem"],
         [project_dir, "git push origin main v#{next_version}"]
@@ -397,7 +405,11 @@ RSpec.describe Mono::Cli::Publish do
       expect(performed_commands).to eql([
         [project_dir, "gem build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
+        [
+          project_dir,
+          "git commit -m 'Publish package v#{next_version}' " \
+            "-m 'Update version number and CHANGELOG.md.'"
+        ],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "gem push package_a-#{next_version}.gem"],
         [project_dir, "git push origin main v#{next_version}"]
@@ -460,7 +472,11 @@ RSpec.describe Mono::Cli::Publish do
       expect(performed_commands).to eql([
         [project_dir, "gem build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
+        [
+          project_dir,
+          "git commit -m 'Publish package v#{next_version}' " \
+            "-m 'Update version number and CHANGELOG.md.'"
+        ],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "gem push package_a-#{next_version}.gem"],
         [project_dir, "git push origin main v#{next_version}"]
@@ -519,7 +535,11 @@ RSpec.describe Mono::Cli::Publish do
       expect(performed_commands).to eql([
         [project_dir, "gem build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
+        [
+          project_dir,
+          "git commit -m 'Publish package v#{next_version}' " \
+            "-m 'Update version number and CHANGELOG.md.'"
+        ],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "gem push package_a-#{next_version}.gem"],
         [project_dir, "git push origin main v#{next_version}"]
@@ -603,7 +623,11 @@ RSpec.describe Mono::Cli::Publish do
         [project_dir, "gem build"],
         [project_dir, "echo after build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
+        [
+          project_dir,
+          "git commit -m 'Publish package v#{next_version}' " \
+            "-m 'Update version number and CHANGELOG.md.'"
+        ],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "echo before publish"],
         [project_dir, "gem push ruby_single_project-#{next_version}.gem"],
@@ -648,7 +672,11 @@ RSpec.describe Mono::Cli::Publish do
         [package_two_dir, "mix deps.get"],
         [package_one_dir, "mix compile"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- #{tag}'"],
+        [
+          project_dir,
+          "git commit -m 'Publish package #{tag}' " \
+            "-m 'Update version number and CHANGELOG.md.'"
+        ],
         [project_dir, "git tag #{tag}"],
         [package_one_dir, "mix hex.publish package --yes"],
         [project_dir, "git push origin main #{tag}"]
@@ -693,7 +721,13 @@ RSpec.describe Mono::Cli::Publish do
         [package_one_dir, "mix compile"],
         [package_two_dir, "mix compile"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- #{tag1}\n- #{tag2}'"],
+        [
+          project_dir,
+          "git commit -m 'Publish packages' " \
+            "-m 'Update version number and CHANGELOG.md.\n\n" \
+            "- #{tag1}\n" \
+            "- #{tag2}'"
+        ],
         [project_dir, "git tag #{tag1}"],
         [project_dir, "git tag #{tag2}"],
         [package_one_dir, "mix hex.publish package --yes"],

--- a/spec/lib/mono/cli/publish/custom_spec.rb
+++ b/spec/lib/mono/cli/publish/custom_spec.rb
@@ -57,7 +57,11 @@ RSpec.describe Mono::Cli::Publish do
       [project_dir, "ruby write_version_file.rb #{next_version}"],
       [project_dir, "echo build"],
       [project_dir, "git add -A"],
-      [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
+      [
+        project_dir,
+        "git commit -m 'Publish package v#{next_version}' " \
+          "-m 'Update version number and CHANGELOG.md.'"
+      ],
       [project_dir, "git tag v#{next_version}"],
       [project_dir, "echo publish"],
       [project_dir, "git push origin main v#{next_version}"]

--- a/spec/lib/mono/cli/publish/elixir_spec.rb
+++ b/spec/lib/mono/cli/publish/elixir_spec.rb
@@ -49,7 +49,11 @@ RSpec.describe Mono::Cli::Publish do
         [project_dir, "mix deps.get"],
         [project_dir, "mix compile"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
+        [
+          project_dir,
+          "git commit -m 'Publish package v#{next_version}' " \
+            "-m 'Update version number and CHANGELOG.md.'"
+        ],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "mix hex.publish package --yes"],
         [project_dir, "git push origin main v#{next_version}"]
@@ -104,7 +108,11 @@ RSpec.describe Mono::Cli::Publish do
         [project_dir, "mix deps.get"],
         [project_dir, "mix compile"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
+        [
+          project_dir,
+          "git commit -m 'Publish package v#{next_version}' " \
+            "-m 'Update version number and CHANGELOG.md.'"
+        ],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "mix hex.publish package --yes"],
         [project_dir, "git push origin main v#{next_version}"]
@@ -140,7 +148,11 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "mix deps.get"],
           [project_dir, "mix compile"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
+          [
+            project_dir,
+            "git commit -m 'Publish package v#{next_version}' " \
+              "-m 'Update version number and CHANGELOG.md.'"
+          ],
           [project_dir, "git tag v#{next_version}"],
           [project_dir, "mix hex.publish package --yes"]
         ])
@@ -206,7 +218,11 @@ RSpec.describe Mono::Cli::Publish do
         [package_dir_b, "mix deps.get"],
         [package_dir_a, "mix compile"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- #{tag}'"],
+        [
+          project_dir,
+          "git commit -m 'Publish package #{tag}' " \
+            "-m 'Update version number and CHANGELOG.md.'"
+        ],
         [project_dir, "git tag #{tag}"],
         [package_dir_a, "mix hex.publish package --yes"],
         [project_dir, "git push origin main #{tag}"]
@@ -290,8 +306,11 @@ RSpec.describe Mono::Cli::Publish do
         [package_dir_a, "mix compile"],
         [package_dir_b, "mix compile"],
         [project_dir, "git add -A"],
-        [project_dir,
-         "git commit -m 'Publish packages' -m '- #{tag_a}\n- #{tag_b}'"],
+        [
+          project_dir,
+          "git commit -m 'Publish packages' " \
+            "-m 'Update version number and CHANGELOG.md.\n\n- #{tag_a}\n- #{tag_b}'"
+        ],
         [project_dir, "git tag #{tag_a}"],
         [project_dir, "git tag #{tag_b}"],
         [package_dir_a, "mix hex.publish package --yes"],

--- a/spec/lib/mono/cli/publish/nodejs_spec.rb
+++ b/spec/lib/mono/cli/publish/nodejs_spec.rb
@@ -52,7 +52,10 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm link"],
           [project_dir, "npm run build"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}'"],
+          [
+            project_dir,
+            "git commit -m 'Publish package #{tag}' -m 'Update version number and CHANGELOG.md.'"
+          ],
           [project_dir, "git tag #{tag}"],
           [project_dir, "npm publish"],
           [project_dir, "git push origin main #{tag}"]
@@ -94,7 +97,10 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm link"],
           [project_dir, "npm run build"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}'"],
+          [
+            project_dir,
+            "git commit -m 'Publish package #{tag}' -m 'Update version number and CHANGELOG.md.'"
+          ],
           [project_dir, "git tag #{tag}"],
           [project_dir, "npm publish --tag alpha"],
           [project_dir, "git push origin main #{tag}"]
@@ -136,7 +142,10 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm link"],
           [project_dir, "npm run build"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}'"],
+          [
+            project_dir,
+            "git commit -m 'Publish package #{tag}' -m 'Update version number and CHANGELOG.md.'"
+          ],
           [project_dir, "git tag #{tag}"],
           [project_dir, "npm publish --tag beta"],
           [project_dir, "git push origin main #{tag}"]
@@ -179,7 +188,10 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm link"],
           [project_dir, "npm run build"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}'"],
+          [
+            project_dir,
+            "git commit -m 'Publish package #{tag}' -m 'Update version number and CHANGELOG.md.'"
+          ],
           [project_dir, "git tag #{tag}"],
           [project_dir, "npm publish --tag #{package_tag}"],
           [project_dir, "git push origin main #{tag}"]
@@ -221,7 +233,10 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm link"],
           [project_dir, "npm run build"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}'"],
+          [
+            project_dir,
+            "git commit -m 'Publish package #{tag}' -m 'Update version number and CHANGELOG.md.'"
+          ],
           [project_dir, "git tag #{tag}"],
           [project_dir, "npm publish --tag rc"],
           [project_dir, "git push origin main #{tag}"]
@@ -258,8 +273,11 @@ RSpec.describe Mono::Cli::Publish do
             [project_dir, "npm link"],
             [project_dir, "npm run build"],
             [project_dir, "git add -A"],
-            [project_dir,
-             "git commit -m 'Publish packages' -m '- v#{next_version}'"],
+            [
+              project_dir,
+              "git commit -m 'Publish package v#{next_version}' " \
+                "-m 'Update version number and CHANGELOG.md.'"
+            ],
             [project_dir, "git tag v#{next_version}"],
             [project_dir, "npm publish"]
           ])
@@ -325,7 +343,10 @@ RSpec.describe Mono::Cli::Publish do
           [package_two_dir, "npm link"],
           [project_dir, "npm run build --workspace=package_one"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}'"],
+          [
+            project_dir,
+            "git commit -m 'Publish package #{tag}' -m 'Update version number and CHANGELOG.md.'"
+          ],
           [project_dir, "git tag #{tag}"],
           [package_one_dir, "npm publish"],
           [project_dir, "git push origin main #{tag}"]
@@ -404,7 +425,6 @@ RSpec.describe Mono::Cli::Publish do
           ])
         end
 
-        commit_message = "- #{package_one_tag}\n- #{package_two_tag}"
         expect(performed_commands).to eql([
           [project_dir, "npm install"],
           [package_one_dir, "npm link"],
@@ -412,7 +432,11 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm run build --workspace=package_one"],
           [project_dir, "npm run build --workspace=package_two"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '#{commit_message}'"],
+          [
+            project_dir,
+            "git commit -m 'Publish packages' -m 'Update version number and CHANGELOG.md.\n\n" \
+              "- #{package_one_tag}\n- #{package_two_tag}'"
+          ],
           [project_dir, "git tag #{package_one_tag}"],
           [project_dir, "git tag #{package_two_tag}"],
           [package_one_dir, "npm publish"],
@@ -558,7 +582,6 @@ RSpec.describe Mono::Cli::Publish do
           ])
         end
 
-        commit_message = "- #{package_tag_a}\n- #{package_tag_b}\n- #{package_tag_c}"
         expect(performed_commands).to eql([
           [project_dir, "npm install"],
           [package_dir_a, "npm link"],
@@ -568,7 +591,11 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm run build --workspace=package_b"],
           [project_dir, "npm run build --workspace=package_c"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '#{commit_message}'"],
+          [
+            project_dir,
+            "git commit -m 'Publish packages' -m 'Update version number and CHANGELOG.md.\n\n" \
+              "- #{package_tag_a}\n- #{package_tag_b}\n- #{package_tag_c}'"
+          ],
           [project_dir, "git tag #{package_tag_a}"],
           [project_dir, "git tag #{package_tag_b}"],
           [project_dir, "git tag #{package_tag_c}"],
@@ -651,7 +678,6 @@ RSpec.describe Mono::Cli::Publish do
           ])
         end
 
-        commit_message = "- #{package_tag_a}\n- #{package_tag_b}"
         expect(performed_commands).to eql([
           [project_dir, "npm install"],
           [package_dir_a, "npm link"],
@@ -659,7 +685,11 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm run build --workspace=package_a"],
           [project_dir, "npm run build --workspace=package_b"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '#{commit_message}'"],
+          [
+            project_dir,
+            "git commit -m 'Publish packages' -m 'Update version number and CHANGELOG.md.\n\n" \
+              "- #{package_tag_a}\n- #{package_tag_b}'"
+          ],
           [project_dir, "git tag #{package_tag_a}"],
           [project_dir, "git tag #{package_tag_b}"],
           [package_dir_a, "npm publish --tag alpha"],
@@ -742,7 +772,6 @@ RSpec.describe Mono::Cli::Publish do
           ])
         end
 
-        commit_message = "- #{package_tag_a}\n- #{package_tag_b}"
         expect(performed_commands).to eql([
           [project_dir, "npm install"],
           [package_dir_a, "npm link"],
@@ -750,7 +779,11 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm run build --workspace=package_a"],
           [project_dir, "npm run build --workspace=package_b"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '#{commit_message}'"],
+          [
+            project_dir,
+            "git commit -m 'Publish packages' -m 'Update version number and CHANGELOG.md.\n\n" \
+              "- #{package_tag_a}\n- #{package_tag_b}'"
+          ],
           [project_dir, "git tag #{package_tag_a}"],
           [project_dir, "git tag #{package_tag_b}"],
           [package_dir_a, "npm publish"],
@@ -809,7 +842,10 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "yarn link"],
           [project_dir, "yarn run build"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- #{tag}'"],
+          [
+            project_dir,
+            "git commit -m 'Publish package #{tag}' -m 'Update version number and CHANGELOG.md.'"
+          ],
           [project_dir, "git tag #{tag}"],
           [project_dir, "yarn publish --new-version #{next_version}"],
           [project_dir, "git push origin main #{tag}"]

--- a/spec/lib/mono/cli/publish/ruby_spec.rb
+++ b/spec/lib/mono/cli/publish/ruby_spec.rb
@@ -49,7 +49,11 @@ RSpec.describe Mono::Cli::Publish do
       expect(performed_commands).to eql([
         [project_dir, "gem build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
+        [
+          project_dir,
+          "git commit -m 'Publish package v#{next_version}' " \
+            "-m 'Update version number and CHANGELOG.md.'"
+        ],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "gem push mygem-#{next_version}.gem"],
         [project_dir, "git push origin main v#{next_version}"]
@@ -103,7 +107,11 @@ RSpec.describe Mono::Cli::Publish do
         expect(performed_commands).to eql([
           [project_dir, "gem build"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
+          [
+            project_dir,
+            "git commit -m 'Publish package v#{next_version}' " \
+              "-m 'Update version number and CHANGELOG.md.'"
+          ],
           [project_dir, "git tag v#{next_version}"],
           [project_dir, "gem push mygem-#{next_version}.gem"],
           [project_dir, "gem push mygem-#{next_version}-java.gem"],
@@ -159,7 +167,11 @@ RSpec.describe Mono::Cli::Publish do
       expect(performed_commands).to eql([
         [project_dir, "echo build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
+        [
+          project_dir,
+          "git commit -m 'Publish package v#{next_version}' " \
+            "-m 'Update version number and CHANGELOG.md.'"
+        ],
         [project_dir, "git tag v#{next_version}"],
         [project_dir, "echo push"],
         [project_dir, "git push origin main v#{next_version}"]
@@ -194,7 +206,11 @@ RSpec.describe Mono::Cli::Publish do
         expect(performed_commands).to eql([
           [project_dir, "gem build"],
           [project_dir, "git add -A"],
-          [project_dir, "git commit -m 'Publish packages' -m '- v#{next_version}'"],
+          [
+            project_dir,
+            "git commit -m 'Publish package v#{next_version}' " \
+              "-m 'Update version number and CHANGELOG.md.'"
+          ],
           [project_dir, "git tag v#{next_version}"],
           [project_dir, "gem push mygem-#{next_version}.gem"]
         ])
@@ -257,7 +273,11 @@ RSpec.describe Mono::Cli::Publish do
       expect(performed_commands).to eql([
         [package_dir_a, "gem build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '- #{tag_a}'"],
+        [
+          project_dir,
+          "git commit -m 'Publish package #{tag_a}' " \
+            "-m 'Update version number and CHANGELOG.md.'"
+        ],
         [project_dir, "git tag #{tag_a}"],
         [project_dir, "gem push packages/package_a/package_a-#{next_version_a}.gem"],
         [project_dir, "git push origin main #{tag_a}"]
@@ -340,8 +360,11 @@ RSpec.describe Mono::Cli::Publish do
         [package_dir_a, "gem build"],
         [package_dir_b, "gem build"],
         [project_dir, "git add -A"],
-        [project_dir,
-         "git commit -m 'Publish packages' -m '- #{tag_a}\n- #{tag_b}'"],
+        [
+          project_dir,
+          "git commit -m 'Publish packages' " \
+            "-m 'Update version number and CHANGELOG.md.\n\n- #{tag_a}\n- #{tag_b}'"
+        ],
         [project_dir, "git tag #{tag_a}"],
         [project_dir, "git tag #{tag_b}"],
         [project_dir, "gem push packages/package_a/package_a-#{next_version_a}.gem"],
@@ -449,13 +472,16 @@ RSpec.describe Mono::Cli::Publish do
         ])
       end
 
-      message = "- #{tag_a}\n- #{tag_b}\n- #{tag_c}"
       expect(performed_commands).to eql([
         [package_dir_a, "gem build"],
         [package_dir_b, "gem build"],
         [package_dir_c, "gem build"],
         [project_dir, "git add -A"],
-        [project_dir, "git commit -m 'Publish packages' -m '#{message}'"],
+        [
+          project_dir,
+          "git commit -m 'Publish packages' " \
+            "-m 'Update version number and CHANGELOG.md.\n\n- #{tag_a}\n- #{tag_b}\n- #{tag_c}'"
+        ],
         [project_dir, "git tag #{tag_a}"],
         [project_dir, "git tag #{tag_b}"],
         [project_dir, "git tag #{tag_c}"],


### PR DESCRIPTION
When a single package is published, don't say "Publish packages", but use the singular form and show the version number in the subject.

Add a small description of what was changed to pass the Lintje MessagePresence rule. The version number alone isn't enough in most cases for single package releases.