### PR TITLE
Implement Python version scheme

### DIFF
--- a/lib/mono/config.rb
+++ b/lib/mono/config.rb
@@ -47,5 +47,13 @@ module Mono
     def config(key)
       @config.fetch(key) { raise "No config found for key '#{key}'" }
     end
+
+    def version_scheme
+      Version::VERSION_SCHEMES[@config["version_scheme"]] || Version::Semver
+    end
+
+    def inspect
+      @config.inspect
+    end
   end
 end

--- a/lib/mono/languages/custom/package.rb
+++ b/lib/mono/languages/custom/package.rb
@@ -12,7 +12,7 @@ module Mono
                 :capture => true,
                 :print_command => false
               ).strip
-              Version.parse(version)
+              config.version_scheme.parse(version)
             else
               raise NotImplementedError,
                 "Please add `read_version` config to `mono.yml` file."

--- a/lib/mono/languages/elixir/package.rb
+++ b/lib/mono/languages/elixir/package.rb
@@ -9,7 +9,7 @@ module Mono
             begin
               contents = read_mix_exs
               matches = VERSION_REGEX.match(contents)
-              Version.parse(matches[2])
+              Version::Semver.parse(matches[2])
             end
         end
 

--- a/lib/mono/languages/nodejs/package.rb
+++ b/lib/mono/languages/nodejs/package.rb
@@ -18,7 +18,7 @@ module Mono
             begin
               contents = read_package_json
               matches = VERSION_REGEX.match(contents)
-              Version.parse(matches[1])
+              Version::Semver.parse(matches[1])
             end
         end
 

--- a/lib/mono/languages/ruby/package.rb
+++ b/lib/mono/languages/ruby/package.rb
@@ -9,7 +9,7 @@ module Mono
             begin
               contents = read_version
               matches = VERSION_REGEX.match(contents)
-              Version.parse_ruby(matches[1])
+              Version::Ruby.parse(matches[1])
             end
         end
 

--- a/lib/mono/version_object.rb
+++ b/lib/mono/version_object.rb
@@ -2,47 +2,145 @@
 
 module Mono
   class Version
-    # Parse both formats for version numbers using prereleases.
-    # The Ruby gem uses a dot (.) between the version number and the
-    # prerelease, e.g. "1.2.3.alpha.1".
-    # The Elixir and Node.js packages use a dash (-) between the version number
-    # and the prerelease, e.g. "1.2.3-alpha.1".
-    def self.parse(string, separator: "-")
-      string = string.sub(separator, ".")
-      major, minor, patch, prerelease_type, prerelease_version =
-        Gem::Version.new(string).segments
+    # The Elixir and Node.js package versions follow the semantic
+    # versioning standard, which uses a dash (-) between the version
+    # number and the pre-release, e.g. "1.2.3-alpha.1".
+    class Semver < Version
+      def self.parse(string)
+        string = string.sub("-", ".")
+        major, minor, patch, prerelease_type, prerelease_version =
+          Gem::Version.new(string).segments
 
-      new(
-        major,
-        minor,
-        patch,
-        prerelease_type,
-        prerelease_version,
-        :separator => separator
-      )
+        new(major, minor, patch, prerelease_type, prerelease_version)
+      end
+
+      def to_s
+        base = [major, minor, patch].join(".")
+        if prerelease?
+          "#{base}-#{prerelease_type}.#{prerelease_version}"
+        else
+          base
+        end
+      end
     end
 
-    def self.parse_ruby(string)
-      parse(string, :separator => ".")
+    # The Ruby gem versions use a dot (.) between the version number and the
+    # pre-release, e.g. "1.2.3.alpha.1".
+    class Ruby < Version
+      def self.parse(string)
+        major, minor, patch, prerelease_type, prerelease_version =
+          Gem::Version.new(string).segments
+
+        new(major, minor, patch, prerelease_type, prerelease_version)
+      end
+
+      def to_s
+        [major, minor, patch, prerelease_type,
+         prerelease_version].compact.join(".")
+      end
     end
 
-    attr_reader :major, :minor, :patch, :prerelease_type, :prerelease_version,
-      :separator
+    # The Python package versions use a custom version scheme, defined in
+    # PEP 440, with different pre-release type names, and with no separator
+    # between the version, the pre-release type, and the pre-release version,
+    # e.g. "1.2.3a1"
+    class Python < Version
+      # https://peps.python.org/pep-0440/#pre-release-separators
+      # This regular expression allows for ".", "-" and "_" as pre-release
+      # separators, and allows for a separator between the pre-release type
+      # and the pre-release version.
+      # It also allows for additional "release" segments beyond major, minor
+      # and patch, which are ignored.
+      VERSION_MATCHER = /
+        ^v?                                              # v      -- ignored
+        (?<major>\d+)\.?(?<minor>\d+)?\.?(?<patch>\d+)?  # 1.2.3
+        (?:\.\d+)*                                       # .4.5   -- ignored
+        (?:
+          [.\-_]?                                        # .      -- ignored
+          (?<pre_type>a|alpha|b|beta|c|rc|pre|preview)   # rc
+          [.\-_]?                                        # .      -- ignored
+          (?<pre_version>\d+)?                           # 4
+        )?$
+      /ix
 
-    def initialize( # rubocop:disable Metrics/ParameterLists
+      # Maps from Mono pre-release types to Python pre-release types.
+      PRERELEASE_TYPE_TO_S = {
+        "alpha" => "a",
+        "beta" => "b",
+        "rc" => "rc"
+      }.freeze
+
+      # https://peps.python.org/pep-0440/#pre-release-spelling
+      # For compatibility, "alpha" is allowed as an alternative form for "a",
+      # "beta" is allowed as an alternative form of "b", and all of "c", "pre"
+      # and "preview" are allowed as alternative forms of "rc".
+      # This map does not normalise those pre-release types to the PEP-defined
+      # forms ("a", "b", "rc") but to the ones used throughout Mono ("alpha",
+      # "beta", "rc")
+      PRERELEASE_TYPE_PARSE = {
+        "a" => "alpha",
+        "alpha" => "alpha",
+        "b" => "beta",
+        "beta" => "beta",
+        "c" => "rc",
+        "pre" => "rc",
+        "preview" => "rc",
+        "rc" => "rc"
+      }.freeze
+
+      def self.parse(string)
+        match = VERSION_MATCHER.match(string.strip)
+        major, minor, patch, prerelease_type, prerelease_version =
+          match.values_at(:major, :minor, :patch, :pre_type, :pre_version)
+
+        if prerelease_type
+          prerelease_type = PRERELEASE_TYPE_PARSE[prerelease_type]
+          # https://peps.python.org/pep-0440/#implicit-pre-release-number
+          # For compatibility, `1.1a` is allowed as a shorthand for `1.1a0`.
+          prerelease_version = prerelease_version.to_i
+        end
+
+        new(major.to_i, minor.to_i, patch.to_i, prerelease_type,
+          prerelease_version)
+      end
+
+      def to_s
+        base = [major, minor, patch].compact.join(".")
+        if prerelease?
+          "#{base}#{PRERELEASE_TYPE_TO_S[prerelease_type]}#{prerelease_version}"
+        else
+          base
+        end
+      end
+    end
+
+    VERSION_SCHEMES = {
+      "semver" => Version::Semver,
+      "ruby" => Version::Ruby,
+      "python" => Version::Python
+    }.freeze
+
+    attr_reader :major, :minor, :patch, :prerelease_type, :prerelease_version
+
+    def initialize(
       major,
       minor,
       patch,
       prerelease_type = nil,
-      prerelease_version = nil,
-      separator: "-"
+      prerelease_version = nil
     )
       @major = major
       @minor = minor
       @patch = patch
       @prerelease_type = prerelease_type
       @prerelease_version = prerelease_version
-      @separator = separator
+    end
+
+    # Return a new object of the same class as the current object. This is
+    # used to generate a new version object with the same serialisation rules
+    # as the current version object.
+    def with(*args)
+      self.class.new(*args)
     end
 
     def prerelease?
@@ -63,12 +161,8 @@ module Mono
     end
 
     def to_s
-      base = [major, minor, patch].join(".")
-      if prerelease?
-        "#{base}#{separator}#{prerelease_type}.#{prerelease_version}"
-      else
-        base
-      end
+      raise NoMethodError,
+        "the Mono::Version superclass does not implement `to_s`"
     end
 
     # Returns segments of the version object

--- a/lib/mono/version_promoter.rb
+++ b/lib/mono/version_promoter.rb
@@ -89,7 +89,7 @@ module Mono
           base
         end
 
-      Version.new(*segments, :separator => version.separator)
+      version.with(*segments)
     end
 
     def self.promote_base(version, bump)

--- a/spec/lib/mono/cli/publish/custom_spec.rb
+++ b/spec/lib/mono/cli/publish/custom_spec.rb
@@ -10,10 +10,11 @@ RSpec.describe Mono::Cli::Publish do
       "build" => { "command" => "echo build" },
       "publish" => { "command" => "echo publish" },
       "read_version" => "cat version.py",
-      "write_version" => "ruby write_version_file.rb"
+      "write_version" => "ruby write_version_file.rb",
+      "version_scheme" => "python"
     }
     prepare_custom_project mono_config do
-      create_version_file "1.2.3"
+      create_version_file "1.2.3a1"
       File.write("write_version_file.rb", %(File.write("version.py", ARGV[0])))
       add_changeset :patch
     end
@@ -21,19 +22,19 @@ RSpec.describe Mono::Cli::Publish do
     output = run_publish_process
 
     project_dir = "/#{current_project}"
-    next_version = "1.2.4"
+    next_version = "1.2.3a2"
 
     expect(output).to include(<<~OUTPUT), output
       The following packages will be published (or not):
       - #{current_project}:
-        Current version: v1.2.3
-        Next version:    v1.2.4 (patch)
+        Current version: v1.2.3a1
+        Next version:    v1.2.3a2 (patch)
     OUTPUT
     expect(output).to include(<<~OUTPUT), output
       # Updating package versions
       - #{current_project}:
-        Current version: v1.2.3
-        Next version:    v1.2.4 (patch)
+        Current version: v1.2.3a1
+        Next version:    v1.2.3a2 (patch)
     OUTPUT
 
     in_project do
@@ -87,7 +88,7 @@ RSpec.describe Mono::Cli::Publish do
           perform_commands do
             fail_commands failed_commands do
               stub_commands stubbed_commands do
-                run_publish
+                run_publish(["--alpha"])
               end
             end
           end

--- a/spec/lib/mono/languages/elixir/package_spec.rb
+++ b/spec/lib/mono/languages/elixir/package_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Mono::Languages::Elixir::Package do
         create_package_with_dependencies package_name, {}
 
         package = package_for_path(package_name)
-        expect(package.current_version).to eql(Mono::Version.new(1, 2, 3))
+        expect(package.current_version).to eql(Mono::Version::Semver.new(1, 2, 3))
       end
     end
 
@@ -20,7 +20,7 @@ RSpec.describe Mono::Languages::Elixir::Package do
         create_package_with_dependencies package_name, {}, true
 
         package = package_for_path(package_name)
-        expect(package.current_version).to eql(Mono::Version.new(1, 2, 3))
+        expect(package.current_version).to eql(Mono::Version::Semver.new(1, 2, 3))
       end
     end
   end

--- a/spec/lib/mono/version_promoter_spec.rb
+++ b/spec/lib/mono/version_promoter_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Mono::VersionPromoter do
   def promote(version, bump, prerelease = nil)
-    version_object = Mono::Version.parse(version)
+    version_object = Mono::Version::Semver.parse(version)
     described_class.promote(version_object, bump, prerelease).to_s
   end
 

--- a/spec/lib/mono/version_spec.rb
+++ b/spec/lib/mono/version_spec.rb
@@ -1,12 +1,71 @@
 # frozen_string_literal: true
 
 RSpec.describe Mono::Version do
-  def parse(string)
-    described_class.parse(string)
+  def new(*args)
+    described_class.new(*args)
   end
 
-  def parse_ruby(string)
-    described_class.parse_ruby(string)
+  describe "#segments" do
+    context "with plain release" do
+      it "returns version string" do
+        expect(new(1, 0, 0).segments).to eql([1, 0, 0])
+        expect(new(1, 2, 3).segments).to eql([1, 2, 3])
+      end
+    end
+
+    context "with prerelease" do
+      it "returns version string" do
+        expect(new(1, 0, 0, "alpha", 1).segments).to eql([1, 0, 0, "alpha", 1])
+        expect(new(1, 2, 3, "alpha", 10).segments).to eql([1, 2, 3, "alpha", 10])
+        expect(new(11, 12, 13, "beta", 20).segments).to eql([11, 12, 13, "beta", 20])
+        expect(new(201, 202, 203, "rc", 999).segments).to eql([201, 202, 203, "rc", 999])
+      end
+    end
+  end
+
+  describe "#prerelease?" do
+    context "with prerelease" do
+      it "returns true" do
+        expect(new(1, 2, 3, "alpha", 1).prerelease?).to be_truthy
+        expect(new(1, 2, 3, "beta", 2).prerelease?).to be_truthy
+        expect(new(1, 2, 3, "rc", 3).prerelease?).to be_truthy
+      end
+    end
+
+    context "without prerelease" do
+      it "returns false" do
+        expect(new(1, 2, 3).prerelease?).to be_falsy
+      end
+    end
+  end
+
+  describe "#current_bump" do
+    context "with major bump" do
+      it "returns major" do
+        expect(new(1, 0, 0).current_bump).to eql("major")
+        expect(new(1, 0, 0, "alpha", 2).current_bump).to eql("major")
+      end
+    end
+
+    context "with minor bump" do
+      it "returns minor" do
+        expect(new(1, 2, 0).current_bump).to eql("minor")
+        expect(new(1, 2, 0, "alpha", 3).current_bump).to eql("minor")
+      end
+    end
+
+    context "with patch bump" do
+      it "returns patch" do
+        expect(new(1, 2, 3).current_bump).to eql("patch")
+        expect(new(1, 2, 3, "alpha", 4).current_bump).to eql("patch")
+      end
+    end
+  end
+end
+
+RSpec.describe Mono::Version::Semver do
+  def parse(string)
+    described_class.parse(string)
   end
 
   describe ".parse" do
@@ -29,7 +88,7 @@ RSpec.describe Mono::Version do
       end
     end
 
-    context "with prerelease using a dash (-)" do
+    context "with prerelease" do
       it "returns Version object" do
         expect(parse("1.0.0-alpha.1")).to have_attributes(
           :major => 1,
@@ -61,31 +120,76 @@ RSpec.describe Mono::Version do
         )
       end
     end
+  end
 
-    context "with prerelease using a dot (.)" do
+  describe "#to_s" do
+    context "with plain release" do
+      it "returns version string" do
+        expect(parse("1.0.0").to_s).to eql("1.0.0")
+        expect(parse("1.2.3").to_s).to eql("1.2.3")
+      end
+    end
+
+    context "with prerelease" do
+      it "returns Version string" do
+        expect(parse("1.0.0-alpha.1").to_s).to eql("1.0.0-alpha.1")
+        expect(parse("1.2.3-alpha.10").to_s).to eql("1.2.3-alpha.10")
+        expect(parse("11.12.13-beta.20").to_s).to eql("11.12.13-beta.20")
+        expect(parse("201.202.203-rc.999").to_s).to eql("201.202.203-rc.999")
+      end
+    end
+  end
+end
+
+RSpec.describe Mono::Version::Ruby do
+  def parse(string)
+    described_class.parse(string)
+  end
+
+  describe ".parse" do
+    context "with plain release" do
       it "returns Version object" do
-        expect(parse_ruby("1.0.0.alpha.1")).to have_attributes(
+        expect(parse("1.0.0")).to have_attributes(
+          :major => 1,
+          :minor => 0,
+          :patch => 0,
+          :prerelease_type => nil,
+          :prerelease_version => nil
+        )
+        expect(parse("1.2.3")).to have_attributes(
+          :major => 1,
+          :minor => 2,
+          :patch => 3,
+          :prerelease_type => nil,
+          :prerelease_version => nil
+        )
+      end
+    end
+
+    context "with prerelease" do
+      it "returns Version object" do
+        expect(parse("1.0.0.alpha.1")).to have_attributes(
           :major => 1,
           :minor => 0,
           :patch => 0,
           :prerelease_type => "alpha",
           :prerelease_version => 1
         )
-        expect(parse_ruby("1.2.3.alpha.1")).to have_attributes(
+        expect(parse("1.2.3.alpha.1")).to have_attributes(
           :major => 1,
           :minor => 2,
           :patch => 3,
           :prerelease_type => "alpha",
           :prerelease_version => 1
         )
-        expect(parse_ruby("1.2.3.beta.2")).to have_attributes(
+        expect(parse("1.2.3.beta.2")).to have_attributes(
           :major => 1,
           :minor => 2,
           :patch => 3,
           :prerelease_type => "beta",
           :prerelease_version => 2
         )
-        expect(parse_ruby("1.2.3.rc.3")).to have_attributes(
+        expect(parse("1.2.3.rc.3")).to have_attributes(
           :major => 1,
           :minor => 2,
           :patch => 3,
@@ -104,100 +208,163 @@ RSpec.describe Mono::Version do
       end
     end
 
-    context "with prerelease using a dash (-)" do
+    context "with prerelease" do
       it "returns version string" do
-        expect(parse("1.0.0-alpha.1").to_s).to eql("1.0.0-alpha.1")
-        expect(parse("1.2.3-alpha.10").to_s).to eql("1.2.3-alpha.10")
-        expect(parse("11.12.13-beta.20").to_s).to eql("11.12.13-beta.20")
-        expect(parse("201.202.203-rc.999").to_s).to eql("201.202.203-rc.999")
+        expect(parse("1.0.0.alpha.1").to_s).to eql("1.0.0.alpha.1")
+        expect(parse("1.2.3.alpha.10").to_s).to eql("1.2.3.alpha.10")
+        expect(parse("11.12.13.beta.20").to_s).to eql("11.12.13.beta.20")
+        expect(parse("201.202.203.rc.999").to_s).to eql("201.202.203.rc.999")
+      end
+    end
+  end
+end
+
+RSpec.describe Mono::Version::Python do
+  def parse(string)
+    described_class.parse(string)
+  end
+
+  describe ".parse" do
+    context "with plain release" do
+      it "returns Version object" do
+        expect(parse("1.0.0")).to have_attributes(
+          :major => 1,
+          :minor => 0,
+          :patch => 0,
+          :prerelease_type => nil,
+          :prerelease_version => nil
+        )
+        expect(parse("1.2.3")).to have_attributes(
+          :major => 1,
+          :minor => 2,
+          :patch => 3,
+          :prerelease_type => nil,
+          :prerelease_version => nil
+        )
       end
     end
 
-    context "with prerelease using a dot (.)" do
-      it "returns Version string" do
-        expect(parse_ruby("1.0.0.alpha.1").to_s).to eql("1.0.0.alpha.1")
-        expect(parse_ruby("1.2.3.alpha.10").to_s).to eql("1.2.3.alpha.10")
-        expect(parse_ruby("11.12.13.beta.20").to_s).to eql("11.12.13.beta.20")
-        expect(parse_ruby("201.202.203.rc.999").to_s).to eql("201.202.203.rc.999")
+    context "with plain release with extra segments" do
+      it "ignores extra segments and returns Version object" do
+        expect(parse("1.2.3.4")).to have_attributes(
+          :major => 1,
+          :minor => 2,
+          :patch => 3,
+          :prerelease_type => nil,
+          :prerelease_version => nil
+        )
+      end
+    end
+
+    context "with prerelease" do
+      it "returns Version object" do
+        expect(parse("1.0.0a1")).to have_attributes(
+          :major => 1,
+          :minor => 0,
+          :patch => 0,
+          :prerelease_type => "alpha",
+          :prerelease_version => 1
+        )
+        expect(parse("1.2.3a1")).to have_attributes(
+          :major => 1,
+          :minor => 2,
+          :patch => 3,
+          :prerelease_type => "alpha",
+          :prerelease_version => 1
+        )
+        expect(parse("1.2.3b2")).to have_attributes(
+          :major => 1,
+          :minor => 2,
+          :patch => 3,
+          :prerelease_type => "beta",
+          :prerelease_version => 2
+        )
+        expect(parse("1.2.3rc3")).to have_attributes(
+          :major => 1,
+          :minor => 2,
+          :patch => 3,
+          :prerelease_type => "rc",
+          :prerelease_version => 3
+        )
+      end
+    end
+
+    context "with compatibility prerelease types" do
+      it "returns Version object" do
+        expect(parse("1.2.3alpha1")).to have_attributes(
+          :major => 1,
+          :minor => 2,
+          :patch => 3,
+          :prerelease_type => "alpha",
+          :prerelease_version => 1
+        )
+        expect(parse("1.2.3beta2")).to have_attributes(
+          :major => 1,
+          :minor => 2,
+          :patch => 3,
+          :prerelease_type => "beta",
+          :prerelease_version => 2
+        )
+        expect(parse("1.2.3c3")).to have_attributes(
+          :major => 1,
+          :minor => 2,
+          :patch => 3,
+          :prerelease_type => "rc",
+          :prerelease_version => 3
+        )
+        expect(parse("1.2.3pre3")).to have_attributes(
+          :major => 1,
+          :minor => 2,
+          :patch => 3,
+          :prerelease_type => "rc",
+          :prerelease_version => 3
+        )
+        expect(parse("1.2.3preview3")).to have_attributes(
+          :major => 1,
+          :minor => 2,
+          :patch => 3,
+          :prerelease_type => "rc",
+          :prerelease_version => 3
+        )
+      end
+    end
+
+    context "with compatibility prerelease separators" do
+      it "returns Version object" do
+        [
+          "1.2.3.a1",
+          "1.2.3-a1",
+          "1.2.3_a1",
+          "1.2.3a.1",
+          "1.2.3a-1",
+          "1.2.3a_1"
+        ].each do |version_string|
+          expect(parse(version_string)).to have_attributes(
+            :major => 1,
+            :minor => 2,
+            :patch => 3,
+            :prerelease_type => "alpha",
+            :prerelease_version => 1
+          )
+        end
       end
     end
   end
 
-  describe "#segments" do
+  describe "#to_s" do
     context "with plain release" do
       it "returns version string" do
-        expect(parse("1.0.0").segments).to eql([1, 0, 0])
-        expect(parse("1.2.3").segments).to eql([1, 2, 3])
+        expect(parse("1.0.0").to_s).to eql("1.0.0")
+        expect(parse("1.2.3").to_s).to eql("1.2.3")
       end
     end
 
-    context "with prerelease using a dash (-)" do
-      it "returns version string" do
-        expect(parse("1.0.0-alpha.1").segments).to eql([1, 0, 0, "alpha", 1])
-        expect(parse("1.2.3-alpha.10").segments).to eql([1, 2, 3, "alpha", 10])
-        expect(parse("11.12.13-beta.20").segments).to eql([11, 12, 13, "beta", 20])
-        expect(parse("201.202.203-rc.999").segments).to eql([201, 202, 203, "rc", 999])
-      end
-    end
-
-    context "with prerelease using a dot (.)" do
-      it "returns Version string" do
-        expect(parse_ruby("1.0.0.alpha.1").segments).to eql([1, 0, 0, "alpha", 1])
-        expect(parse_ruby("1.2.3.alpha.10").segments).to eql([1, 2, 3, "alpha", 10])
-        expect(parse_ruby("11.12.13.beta.20").segments).to eql([11, 12, 13, "beta", 20])
-        expect(parse_ruby("201.202.203.rc.999").segments).to eql([201, 202, 203, "rc", 999])
-      end
-    end
-  end
-
-  describe "#prerelease?" do
     context "with prerelease" do
-      context "using a dash (-)" do
-        it "returns true" do
-          expect(parse("1.2.3-alpha.1").prerelease?).to be_truthy
-          expect(parse("1.2.3-beta.2").prerelease?).to be_truthy
-          expect(parse("1.2.3-rc.3").prerelease?).to be_truthy
-        end
-      end
-
-      context "using a dot (.)" do
-        it "returns true" do
-          expect(parse_ruby("1.2.3.alpha.1").prerelease?).to be_truthy
-          expect(parse_ruby("1.2.3.beta.2").prerelease?).to be_truthy
-          expect(parse_ruby("1.2.3.rc.3").prerelease?).to be_truthy
-        end
-      end
-    end
-
-    context "without prerelease" do
-      it "returns false" do
-        expect(parse("1.2.3").prerelease?).to be_falsy
-      end
-    end
-  end
-
-  describe "#current_bump" do
-    context "with major bump" do
-      it "returns major" do
-        expect(parse("1.0.0").current_bump).to eql("major")
-        expect(parse("1.0.0-alpha.2").current_bump).to eql("major")
-        expect(parse_ruby("3.0.0.alpha.4").current_bump).to eql("major")
-      end
-    end
-
-    context "with minor bump" do
-      it "returns minor" do
-        expect(parse("1.2.0").current_bump).to eql("minor")
-        expect(parse("1.2.0-alpha.3").current_bump).to eql("minor")
-        expect(parse_ruby("3.4.0.alpha.5").current_bump).to eql("minor")
-      end
-    end
-
-    context "with patch bump" do
-      it "returns patch" do
-        expect(parse("1.2.3").current_bump).to eql("patch")
-        expect(parse("1.2.3-alpha.4").current_bump).to eql("patch")
-        expect(parse_ruby("5.6.7.alpha.8").current_bump).to eql("patch")
+      it "returns version string" do
+        expect(parse("1.0.0a1").to_s).to eql("1.0.0a1")
+        expect(parse("1.2.3a10").to_s).to eql("1.2.3a10")
+        expect(parse("11.12.13b20").to_s).to eql("11.12.13b20")
+        expect(parse("201.202.203rc999").to_s).to eql("201.202.203rc999")
       end
     end
   end


### PR DESCRIPTION
Split the existing Mono::Version type into three subtypes for Ruby, Semver (Elixir/Node.js) and Python. Implement separate `self.parse` and `.to_s` methods for these subtypes.

Internally, the Python version type stores its pre-release type in the forms already used by Mono ("alpha"/"beta"/"rc") and not the forms used by Python version strings ("a"/"b"/"rc"), converting between the two at the parse/serialise boundaries. This allows for existing code that expects the Mono forms to work correctly.

Implement a Python version subtype that conforms to PEP 440 to the extent of the Mono feature set. Features not present in Mono, such as post-releases and local builds, are not supported.

Add a "version_scheme" key to the config, with possible values of "semver", "ruby" and "python", defaulting to "semver". Use this version scheme, if present, with the custom package type, in order to parse and serialise versions.

Turns out we _did_ have to do this work. Closes #54.