### PR TITLE
Check if tags exist before publishing

### DIFF
--- a/.changesets/check-if-tags-exist-before-publishing.md
+++ b/.changesets/check-if-tags-exist-before-publishing.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+When running `mono publish`, check if the Git tag that is about to be published already exists, and if so, abort the publishing process early.

--- a/lib/mono/cli/publish.rb
+++ b/lib/mono/cli/publish.rb
@@ -39,6 +39,15 @@ module Mono
             "Commit or discard them and try again. Exiting."
         end
 
+        existing_tags = existing_tags(changed_packages)
+        unless existing_tags.empty?
+          message = "Error: The git tags for packages to be published " \
+            "already exist: "
+          message += existing_tags.map(&:inspect).join(",")
+          message += ". Delete them and try again. Exiting."
+          exit_cli message
+        end
+
         print_summary(packages)
         puts
         ask_for_confirmation
@@ -183,6 +192,15 @@ module Mono
       def package_promoter
         @package_promoter ||=
           PackagePromoter.new(dependency_tree, :prerelease => prerelease)
+      end
+
+      def existing_tags(changed_packages)
+        next_tags = changed_packages.map(&:next_tag).join(" ")
+        run_command(
+          "git tag --list #{next_tags}",
+          :capture => true,
+          :print_command => false
+        ).strip.split("\n")
       end
     end
   end

--- a/spec/lib/mono/cli/publish/custom_spec.rb
+++ b/spec/lib/mono/cli/publish/custom_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Mono::Cli::Publish do
 
     expect(performed_commands).to eql([
       [project_dir, "cat version.py"],
+      [project_dir, "git tag --list v#{next_version}"],
       [project_dir, "ruby write_version_file.rb #{next_version}"],
       [project_dir, "echo build"],
       [project_dir, "git add -A"],

--- a/spec/lib/mono/cli/publish/elixir_spec.rb
+++ b/spec/lib/mono/cli/publish/elixir_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Mono::Cli::Publish do
 
       expect(performed_commands).to eql([
         [project_dir, "mix deps.get"],
+        [project_dir, "git tag --list v#{next_version}"],
         [project_dir, "mix compile"],
         [project_dir, "git add -A"],
         [
@@ -106,6 +107,7 @@ RSpec.describe Mono::Cli::Publish do
 
       expect(performed_commands).to eql([
         [project_dir, "mix deps.get"],
+        [project_dir, "git tag --list v#{next_version}"],
         [project_dir, "mix compile"],
         [project_dir, "git add -A"],
         [
@@ -146,6 +148,7 @@ RSpec.describe Mono::Cli::Publish do
 
         expect(performed_commands).to eql([
           [project_dir, "mix deps.get"],
+          [project_dir, "git tag --list v#{next_version}"],
           [project_dir, "mix compile"],
           [project_dir, "git add -A"],
           [
@@ -216,6 +219,7 @@ RSpec.describe Mono::Cli::Publish do
       expect(performed_commands).to eql([
         [package_dir_a, "mix deps.get"],
         [package_dir_b, "mix deps.get"],
+        [project_dir, "git tag --list #{tag}"],
         [package_dir_a, "mix compile"],
         [project_dir, "git add -A"],
         [
@@ -303,6 +307,7 @@ RSpec.describe Mono::Cli::Publish do
       expect(performed_commands).to eql([
         [package_dir_a, "mix deps.get"],
         [package_dir_b, "mix deps.get"],
+        [project_dir, "git tag --list #{tag_a} #{tag_b}"],
         [package_dir_a, "mix compile"],
         [package_dir_b, "mix compile"],
         [project_dir, "git add -A"],

--- a/spec/lib/mono/cli/publish/nodejs_spec.rb
+++ b/spec/lib/mono/cli/publish/nodejs_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe Mono::Cli::Publish do
         expect(performed_commands).to eql([
           [project_dir, "npm install"],
           [project_dir, "npm link"],
+          [project_dir, "git tag --list #{tag}"],
           [project_dir, "npm run build"],
           [project_dir, "git add -A"],
           [
@@ -95,6 +96,7 @@ RSpec.describe Mono::Cli::Publish do
         expect(performed_commands).to eql([
           [project_dir, "npm install"],
           [project_dir, "npm link"],
+          [project_dir, "git tag --list #{tag}"],
           [project_dir, "npm run build"],
           [project_dir, "git add -A"],
           [
@@ -140,6 +142,7 @@ RSpec.describe Mono::Cli::Publish do
         expect(performed_commands).to eql([
           [project_dir, "npm install"],
           [project_dir, "npm link"],
+          [project_dir, "git tag --list #{tag}"],
           [project_dir, "npm run build"],
           [project_dir, "git add -A"],
           [
@@ -186,6 +189,7 @@ RSpec.describe Mono::Cli::Publish do
         expect(performed_commands).to eql([
           [project_dir, "npm install"],
           [project_dir, "npm link"],
+          [project_dir, "git tag --list #{tag}"],
           [project_dir, "npm run build"],
           [project_dir, "git add -A"],
           [
@@ -231,6 +235,7 @@ RSpec.describe Mono::Cli::Publish do
         expect(performed_commands).to eql([
           [project_dir, "npm install"],
           [project_dir, "npm link"],
+          [project_dir, "git tag --list #{tag}"],
           [project_dir, "npm run build"],
           [project_dir, "git add -A"],
           [
@@ -271,6 +276,7 @@ RSpec.describe Mono::Cli::Publish do
           expect(performed_commands).to eql([
             [project_dir, "npm install"],
             [project_dir, "npm link"],
+            [project_dir, "git tag --list v#{next_version}"],
             [project_dir, "npm run build"],
             [project_dir, "git add -A"],
             [
@@ -341,6 +347,7 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm install"],
           [package_one_dir, "npm link"],
           [package_two_dir, "npm link"],
+          [project_dir, "git tag --list #{tag}"],
           [project_dir, "npm run build --workspace=package_one"],
           [project_dir, "git add -A"],
           [
@@ -429,6 +436,7 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm install"],
           [package_one_dir, "npm link"],
           [package_two_dir, "npm link"],
+          [project_dir, "git tag --list #{package_one_tag} #{package_two_tag}"],
           [project_dir, "npm run build --workspace=package_one"],
           [project_dir, "npm run build --workspace=package_two"],
           [project_dir, "git add -A"],
@@ -587,6 +595,7 @@ RSpec.describe Mono::Cli::Publish do
           [package_dir_a, "npm link"],
           [package_dir_b, "npm link"],
           [package_dir_c, "npm link"],
+          [project_dir, "git tag --list #{package_tag_a} #{package_tag_b} #{package_tag_c}"],
           [project_dir, "npm run build --workspace=package_a"],
           [project_dir, "npm run build --workspace=package_b"],
           [project_dir, "npm run build --workspace=package_c"],
@@ -682,6 +691,7 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm install"],
           [package_dir_a, "npm link"],
           [package_dir_b, "npm link"],
+          [project_dir, "git tag --list #{package_tag_a} #{package_tag_b}"],
           [project_dir, "npm run build --workspace=package_a"],
           [project_dir, "npm run build --workspace=package_b"],
           [project_dir, "git add -A"],
@@ -776,6 +786,7 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, "npm install"],
           [package_dir_a, "npm link"],
           [package_dir_b, "npm link"],
+          [project_dir, "git tag --list #{package_tag_a} #{package_tag_b}"],
           [project_dir, "npm run build --workspace=package_a"],
           [project_dir, "npm run build --workspace=package_b"],
           [project_dir, "git add -A"],
@@ -840,6 +851,7 @@ RSpec.describe Mono::Cli::Publish do
         expect(performed_commands).to eql([
           [project_dir, "yarn install"],
           [project_dir, "yarn link"],
+          [project_dir, "git tag --list #{tag}"],
           [project_dir, "yarn run build"],
           [project_dir, "git add -A"],
           [

--- a/spec/lib/mono/cli/publish/ruby_spec.rb
+++ b/spec/lib/mono/cli/publish/ruby_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Mono::Cli::Publish do
       end
 
       expect(performed_commands).to eql([
+        [project_dir, "git tag --list v#{next_version}"],
         [project_dir, "gem build"],
         [project_dir, "git add -A"],
         [
@@ -105,6 +106,7 @@ RSpec.describe Mono::Cli::Publish do
         end
 
         expect(performed_commands).to eql([
+          [project_dir, "git tag --list v#{next_version}"],
           [project_dir, "gem build"],
           [project_dir, "git add -A"],
           [
@@ -165,6 +167,7 @@ RSpec.describe Mono::Cli::Publish do
       end
 
       expect(performed_commands).to eql([
+        [project_dir, "git tag --list v#{next_version}"],
         [project_dir, "echo build"],
         [project_dir, "git add -A"],
         [
@@ -204,6 +207,7 @@ RSpec.describe Mono::Cli::Publish do
         OUTPUT
 
         expect(performed_commands).to eql([
+          [project_dir, "git tag --list v#{next_version}"],
           [project_dir, "gem build"],
           [project_dir, "git add -A"],
           [
@@ -271,6 +275,7 @@ RSpec.describe Mono::Cli::Publish do
       end
 
       expect(performed_commands).to eql([
+        [project_dir, "git tag --list #{tag_a}"],
         [package_dir_a, "gem build"],
         [project_dir, "git add -A"],
         [
@@ -357,6 +362,7 @@ RSpec.describe Mono::Cli::Publish do
       end
 
       expect(performed_commands).to eql([
+        [project_dir, "git tag --list #{tag_a} #{tag_b}"],
         [package_dir_a, "gem build"],
         [package_dir_b, "gem build"],
         [project_dir, "git add -A"],
@@ -473,6 +479,7 @@ RSpec.describe Mono::Cli::Publish do
       end
 
       expect(performed_commands).to eql([
+        [project_dir, "git tag --list #{tag_a} #{tag_b} #{tag_c}"],
         [package_dir_a, "gem build"],
         [package_dir_b, "gem build"],
         [package_dir_c, "gem build"],


### PR DESCRIPTION
Before attempting to publish a new version with `mono publish`, check if the Git tags that would be created for the new versions that are to be released already exist, and if so, throw an error.

Part of #59.