### PR TITLE
Rollback when publishing fails

### DIFF
--- a/.changesets/rollback-when-publishing-fails.md
+++ b/.changesets/rollback-when-publishing-fails.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+When the `mono publish` command fails at or before the publishing step, offer the user the possibility to rollback changes performed to the Git repository.

--- a/lib/mono/command.rb
+++ b/lib/mono/command.rb
@@ -40,8 +40,8 @@ module Mono
           next if answer
         end
 
-        puts "Error: Command failed with status `#{exitstatus.exitstatus}`"
-        exit 1
+        raise Mono::Error,
+          "Command failed with status `#{exitstatus.exitstatus}`"
       end
     end
 

--- a/spec/lib/mono/cli/publish/elixir_spec.rb
+++ b/spec/lib/mono/cli/publish/elixir_spec.rb
@@ -161,6 +161,66 @@ RSpec.describe Mono::Cli::Publish do
         ])
         expect(exit_status).to eql(1), output
       end
+
+      it "rolls back changes" do
+        fail_command = "exit 1"
+        prepare_elixir_project do
+          create_package_mix :version => "1.2.3"
+          add_changeset :patch
+        end
+        confirm_publish_package
+        add_cli_input "n" # Don't retry command
+        add_cli_input "y" # Rollback changes
+        output = run_publish_process(
+          :stubbed_commands => [
+            /^git push/,
+            # Happens after `## Untag package v1.2.4` in output,
+            # stubbed because output contains commit hash
+            /^git tag -d/
+          ],
+          :failed_commands => [/^mix hex.publish package --yes/]
+        )
+
+        project_dir = "/#{current_project}"
+        next_version = "1.2.4"
+
+        expect(output).to include(<<~OUTPUT), output
+          #{fail_command}
+          Error: Command failed. Do you want to retry? (Y/n):#{" "}
+          A Mono error was encountered during the `mono publish` command. Stopping operation.
+
+          Mono::Error: Command failed with status `1`
+
+          Do you want to rollback the above changes? (Y/n)#{" "}
+          # Rolling back changes
+          ## Untag package v1.2.4
+          ## Removing release commit
+          git reset --soft HEAD^
+          git restore --staged :/
+          ## Restoring changelogs
+          git restore :/
+          ## Restoring package versions
+        OUTPUT
+
+        expect(performed_commands).to eql([
+          [project_dir, "mix deps.get"],
+          [project_dir, "git tag --list v#{next_version}"],
+          [project_dir, "mix compile"],
+          [project_dir, "git add -A"],
+          [
+            project_dir,
+            "git commit -m 'Publish package v#{next_version}' " \
+              "-m 'Update version number and CHANGELOG.md.'"
+          ],
+          [project_dir, "git tag v#{next_version}"],
+          [project_dir, "mix hex.publish package --yes"],
+          [project_dir, "git tag -d v1.2.4"],
+          [project_dir, "git reset --soft HEAD^"],
+          [project_dir, "git restore --staged :/"],
+          [project_dir, "git restore :/"]
+        ])
+        expect(exit_status).to eql(1), output
+      end
     end
   end
 

--- a/spec/lib/mono/cli/publish/elixir_spec.rb
+++ b/spec/lib/mono/cli/publish/elixir_spec.rb
@@ -132,6 +132,7 @@ RSpec.describe Mono::Cli::Publish do
         confirm_publish_package
         add_cli_input "y" # Retry command
         add_cli_input "n" # Don't retry command
+        add_cli_input "n" # Don't rollback changes
         output = run_publish_process(
           :stubbed_commands => [/^git push/],
           :failed_commands => [/^mix hex.publish package --yes/]
@@ -143,7 +144,10 @@ RSpec.describe Mono::Cli::Publish do
         expect(output).to include(<<~OUTPUT), output
           #{fail_command}
           Error: Command failed. Do you want to retry? (Y/n): #{fail_command}
-          Error: Command failed. Do you want to retry? (Y/n): Error: Command failed with status `1`
+          Error: Command failed. Do you want to retry? (Y/n):#{" "}
+          A Mono error was encountered during the `mono publish` command. Stopping operation.
+
+          Mono::Error: Command failed with status `1`
         OUTPUT
 
         expect(performed_commands).to eql([

--- a/spec/lib/mono/cli/publish/nodejs_spec.rb
+++ b/spec/lib/mono/cli/publish/nodejs_spec.rb
@@ -289,6 +289,68 @@ RSpec.describe Mono::Cli::Publish do
           ])
           expect(exit_status).to eql(1), output
         end
+
+        it "rolls back changes" do
+          fail_command = "exit 1"
+          prepare_nodejs_project do
+            create_package_json :version => "1.2.3"
+            add_changeset :patch
+          end
+          confirm_publish_package
+          add_cli_input "n" # Don't retry command
+          add_cli_input "y" # Rollback changes
+          output = run_publish_process(
+            :stubbed_commands => [
+              /^git push/,
+              # Happens after `## Untag package v1.2.4` in output,
+              # stubbed because output contains commit hash
+              /^git tag -d/
+            ],
+            :failed_commands => [/^npm publish/]
+          )
+
+          project_dir = "/#{current_project}"
+          next_version = "1.2.4"
+
+          expect(output).to include(<<~OUTPUT), output
+            #{fail_command}
+            Error: Command failed. Do you want to retry? (Y/n):#{" "}
+            A Mono error was encountered during the `mono publish` command. Stopping operation.
+
+            Mono::Error: Command failed with status `1`
+
+            Do you want to rollback the above changes? (Y/n)#{" "}
+            # Rolling back changes
+            ## Untag package v1.2.4
+            ## Removing release commit
+            git reset --soft HEAD^
+            git restore --staged :/
+            ## Restoring changelogs
+            git restore :/
+            ## Restoring package versions
+          OUTPUT
+
+          expect(performed_commands).to eql([
+            [project_dir, "npm install"],
+            [project_dir, "npm link"],
+            [project_dir, "git tag --list v#{next_version}"],
+            [project_dir, "npm run build"],
+            [project_dir, "git add -A"],
+            [
+              project_dir,
+              "git commit -m 'Publish package v#{next_version}' " \
+                "-m 'Update version number and CHANGELOG.md.'"
+            ],
+            [project_dir, "git tag v#{next_version}"],
+            [project_dir, "npm publish"],
+            [project_dir, "git tag -d v1.2.4"],
+            [project_dir, "git reset --soft HEAD^"],
+            [project_dir, "git restore --staged :/"],
+            [project_dir, "git restore :/"]
+
+          ])
+          expect(exit_status).to eql(1), output
+        end
       end
     end
 

--- a/spec/lib/mono/cli/publish/nodejs_spec.rb
+++ b/spec/lib/mono/cli/publish/nodejs_spec.rb
@@ -259,6 +259,7 @@ RSpec.describe Mono::Cli::Publish do
           confirm_publish_package
           add_cli_input "y" # Retry command
           add_cli_input "n" # Don't retry command
+          add_cli_input "n" # Don't rollback changes
           output = run_publish_process(
             :stubbed_commands => [/^git push/],
             :failed_commands => [/^npm publish/]
@@ -270,7 +271,10 @@ RSpec.describe Mono::Cli::Publish do
           expect(output).to include(<<~OUTPUT), output
             #{fail_command}
             Error: Command failed. Do you want to retry? (Y/n): #{fail_command}
-            Error: Command failed. Do you want to retry? (Y/n): Error: Command failed with status `1`
+            Error: Command failed. Do you want to retry? (Y/n):#{" "}
+            A Mono error was encountered during the `mono publish` command. Stopping operation.
+
+            Mono::Error: Command failed with status `1`
           OUTPUT
 
           expect(performed_commands).to eql([

--- a/spec/lib/mono/cli/publish/ruby_spec.rb
+++ b/spec/lib/mono/cli/publish/ruby_spec.rb
@@ -192,6 +192,7 @@ RSpec.describe Mono::Cli::Publish do
         confirm_publish_package
         add_cli_input "y" # Retry command
         add_cli_input "n" # Don't retry command
+        add_cli_input "n" # Don't rollback changes
         output = run_publish_process(
           :stubbed_commands => [/^git push/],
           :failed_commands => [/^gem push/]
@@ -203,7 +204,10 @@ RSpec.describe Mono::Cli::Publish do
         expect(output).to include(<<~OUTPUT), output
           #{fail_command}
           Error: Command failed. Do you want to retry? (Y/n): #{fail_command}
-          Error: Command failed. Do you want to retry? (Y/n): Error: Command failed with status `1`
+          Error: Command failed. Do you want to retry? (Y/n):#{" "}
+          A Mono error was encountered during the `mono publish` command. Stopping operation.
+
+          Mono::Error: Command failed with status `1`
         OUTPUT
 
         expect(performed_commands).to eql([

--- a/spec/lib/mono/cli/publish/ruby_spec.rb
+++ b/spec/lib/mono/cli/publish/ruby_spec.rb
@@ -220,6 +220,65 @@ RSpec.describe Mono::Cli::Publish do
         ])
         expect(exit_status).to eql(1), output
       end
+
+      it "rolls back changes" do
+        fail_command = "exit 1"
+        prepare_ruby_project do
+          create_ruby_package_files :name => "mygem", :version => "1.2.3"
+          add_changeset :patch
+        end
+        confirm_publish_package
+        add_cli_input "n" # Don't retry command
+        add_cli_input "y" # Rollback changes
+        output = run_publish_process(
+          :stubbed_commands => [
+            /^git push/,
+            # Happens after `## Untag package v1.2.4` in output,
+            # stubbed because output contains commit hash
+            /^git tag -d/
+          ],
+          :failed_commands => [/^gem push/]
+        )
+
+        project_dir = "/#{current_project}"
+        next_version = "1.2.4"
+
+        expect(output).to include(<<~OUTPUT), output
+          #{fail_command}
+          Error: Command failed. Do you want to retry? (Y/n):#{" "}
+          A Mono error was encountered during the `mono publish` command. Stopping operation.
+
+          Mono::Error: Command failed with status `1`
+
+          Do you want to rollback the above changes? (Y/n)#{" "}
+          # Rolling back changes
+          ## Untag package v1.2.4
+          ## Removing release commit
+          git reset --soft HEAD^
+          git restore --staged :/
+          ## Restoring changelogs
+          git restore :/
+          ## Restoring package versions
+        OUTPUT
+
+        expect(performed_commands).to eql([
+          [project_dir, "git tag --list v#{next_version}"],
+          [project_dir, "gem build"],
+          [project_dir, "git add -A"],
+          [
+            project_dir,
+            "git commit -m 'Publish package v#{next_version}' " \
+              "-m 'Update version number and CHANGELOG.md.'"
+          ],
+          [project_dir, "git tag v#{next_version}"],
+          [project_dir, "gem push mygem-#{next_version}.gem"],
+          [project_dir, "git tag -d v1.2.4"],
+          [project_dir, "git reset --soft HEAD^"],
+          [project_dir, "git restore --staged :/"],
+          [project_dir, "git restore :/"]
+        ])
+        expect(exit_status).to eql(1), output
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,7 @@ end
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+    expectations.max_formatted_output_length = nil
   end
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true


### PR DESCRIPTION
Implements partial rollback functionality for the publish command. Focused around the more common case of the publishing step itself failing -- rolling back after that step is IMO unlikely to be useful.

Part of #59.

## Commits

### [Implement rollback for publish command](https://github.com/appsignal/mono/pull/61/commits/6fbaec9fb56195f3704e778142e267896b5641b8)

As the publish command performs different modifications on the state
of the Git repository that it is publishing, keep track of the
commands needed to roll back those modifications. If the publish
command (or any intermediate commands) fail, ask the user whether
they'd like to rollback these changes.

### [Amend retry tests for rollback](https://github.com/appsignal/mono/pull/61/commits/e7c28e02ddc8bf5413dc714904ca99b631989c27)

Modify the existing retry tests to reject rollbacks and expect the
new error output.

### [Do not truncate expectation diffs](https://github.com/appsignal/mono/pull/61/commits/f1ff284a076a39cd16007479ab621a03b061ccf1)

Many of the tests in the test suite compare big objects (long output
strings, or long lists of performed commands) to each other. Being
able to see the whole diff in the output of a failed test is helpful.