### PR TITLE
Remove backticks from changeset file names

### DIFF
--- a/.changesets/remove-backticks-from-changeset-filename.md
+++ b/.changesets/remove-backticks-from-changeset-filename.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix changeset filenames containing a backticks by replacing it with a dash (`-`). If a backtick was present in the changeset description it would fail to open the right file when prompted.

--- a/lib/mono/cli/changeset/add.rb
+++ b/lib/mono/cli/changeset/add.rb
@@ -19,7 +19,7 @@ module Mono
           FileUtils.touch(File.join(dir, ".gitkeep"))
           change_description =
             required_input("Summarize the change (for changeset filename): ")
-          filename = change_description.downcase.tr(":;.,'\" /\\", "-")
+          filename = change_description.downcase.tr(":;.,'\"` /\\", "-")
           filepath = File.join(dir, "#{filename}.md")
           type = prompt_for_type
           bump = prompt_for_bump

--- a/spec/lib/mono/cli/changeset/add_spec.rb
+++ b/spec/lib/mono/cli/changeset/add_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Mono::Cli::Changeset do
       it "creates the .changeset directory and a changeset file" do
         prepare_project :elixir_single
 
-        add_cli_input "My Awes/o\\me pa.tch"
+        add_cli_input "My Awes/o\\me pa.t`ch"
         add_cli_input "1" # Type: "add"
         add_cli_input "minor"
         add_cli_input "n"
@@ -59,7 +59,7 @@ RSpec.describe Mono::Cli::Changeset do
             end
           end
 
-        changeset_path = ".changesets/my-awes-o-me-pa-tch.md"
+        changeset_path = ".changesets/my-awes-o-me-pa-t-ch.md"
         expect(output).to include(
           "Summarize the change (for changeset filename):",
           "What type of semver bump is this (major/minor/patch): ",
@@ -75,7 +75,7 @@ RSpec.describe Mono::Cli::Changeset do
             type: "add"
             ---
 
-            My Awes/o\\me pa.tch
+            My Awes/o\\me pa.t`ch
           CHANGESET
         end
         expect(performed_commands).to eql([])


### PR DESCRIPTION
It would fail to open the file when prompted in the `mono changeset add` command.

[skip review]