### PR TITLE
Update Node.js on CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4,7 +4,7 @@ name: Mono
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 auto_cancel:
   running:
     when: branch != 'main' AND branch != 'develop'

--- a/script/ci/ruby_prologue
+++ b/script/ci/ruby_prologue
@@ -5,13 +5,13 @@ set -e
 sem-version ruby 3.2.2
 sem-version erlang 23.3
 sem-version elixir 1.11.3
+sem-version node 20
 
 set -u
 
 cache restore $_BUNDLER_CACHE-bundler-$(checksum Gemfile)
 cache restore $_GEMS_CACHE-gems-$(checksum Gemfile)
 
-npm install -g npm # TODO: temporary. Currently expected in the tests.
 bundle config set retry 3
 bundle config set jobs 3
 bundle config set path $_BUNDLER_PATH


### PR DESCRIPTION
It fails on the older Node.js version, because it couldn't install the latest npm package for such an old version.

[skip changeset]
[skip review]