### PR TITLE
Add publish date of versions to changelog

### DIFF
--- a/.changesets/add-published-on-date-to-changelog.md
+++ b/.changesets/add-published-on-date-to-changelog.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Add the publish date for each version to the changelog. This allows people to see at a glance when a version was released.

--- a/lib/mono/changeset_collection.rb
+++ b/lib/mono/changeset_collection.rb
@@ -48,9 +48,12 @@ module Mono
       contents = File.read(changelog_path)
       lines = contents.lines # Keep original contents to add to the bottom
       heading = lines.shift # Keep original heading
+      date = Time.now.utc.strftime("%Y-%m-%d")
       File.write(changelog_path, <<~CHANGELOG)
         #{heading}
         ## #{package.next_version}
+
+        _Published on #{date}._
 
         #{content.join.strip}
 

--- a/spec/lib/mono/changeset_collection_spec.rb
+++ b/spec/lib/mono/changeset_collection_spec.rb
@@ -229,6 +229,8 @@ RSpec.describe Mono::ChangesetCollection do
         expect(changelog).to include(<<~CHANGELOG)
           ## 2.0.0
 
+          _Published on #{date_label}._
+
           ### Added
 
           - [LINK] major - This is a major changeset bump.
@@ -276,6 +278,8 @@ RSpec.describe Mono::ChangesetCollection do
         expect(changelog).to include(<<~CHANGELOG)
           ## 2.0.0
 
+          _Published on #{date_label}._
+
           ### Deprecated
 
           - [LINK] patch - This is a patch changeset bump.
@@ -292,5 +296,9 @@ RSpec.describe Mono::ChangesetCollection do
   def normalize_changelog(content)
     # Remove links so we don't have to try and match against every instance
     content.gsub(/\[[a-z0-9]{7}\]\(.+\)/, "[LINK]")
+  end
+
+  def date_label
+    Time.now.utc.strftime("%Y-%m-%d")
   end
 end


### PR DESCRIPTION
Add the publish date to the changelog for each version so it's easier to tell when looking at the changelog when a version of a package was released.

Closes #35