### PR TITLE
Check if directory is mono project

### DIFF
--- a/.changesets/check-if-mono-project.md
+++ b/.changesets/check-if-mono-project.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Check if the directory in which Mono is run is Mono project before performing commands. Previously Mono would error with a non-user friendly Ruby error about a missing file. This case is now handled with a better error message.

--- a/lib/mono/cli.rb
+++ b/lib/mono/cli.rb
@@ -12,7 +12,12 @@ module Mono
 
       def initialize(options = {})
         @options = options
-        @config = Config.new(YAML.safe_load(File.read("mono.yml")))
+        config_file = "mono.yml"
+        unless File.exist?(config_file)
+          exit_cli "No Mono `#{config_file}` config file found in this " \
+            "directory!"
+        end
+        @config = Config.new(YAML.safe_load(File.read(config_file)))
         @language = Language.for(config.language).new(config)
         find_packages
         validate(options)

--- a/spec/lib/mono/cli/global_spec.rb
+++ b/spec/lib/mono/cli/global_spec.rb
@@ -63,18 +63,16 @@ RSpec.describe Mono::Cli do
     end
   end
 
-  context "with unknown error" do
-    it "prints error and exits" do
+  context "with no Mono project in directory" do
+    it "prints error about missing config file and exits" do
       prepare_project :empty
       output =
         capture_stdout do
-          expect do
-            in_project { run(["run", "false"]) }
-          end.to raise_error(SystemCallError)
+          in_project { run(["run", "false"]) }
         end
 
       expect(output).to include(
-        "An unexpected error was encountered during the `mono run` command. Stopping operation."
+        "Mono::Error: No Mono `mono.yml` config file found in this directory!"
       )
       expect(performed_commands).to eql([])
     end


### PR DESCRIPTION
I ran into a bad error message when accidentally running Mono in a directory that isn't a Mono project. Improve the error message for every CLI command, except the `mono init` one, because that initializes Mono in an empty project.