### PR TITLE
Use matcher for package publish summaries

### DIFF
--- a/spec/lib/mono/cli/publish/base_spec.rb
+++ b/spec/lib/mono/cli/publish/base_spec.rb
@@ -186,12 +186,9 @@ RSpec.describe Mono::Cli::Publish do
       do_not_publish_package
       output = run_publish(:lang => :ruby)
 
-      expect(output).to include(<<~OUTPUT), output
-        The following packages will be published (or not):
-        - custom_project_project:
-          Current version: v1.2.3
-          Next version:    v1.2.4 (patch)
-      OUTPUT
+      expect(output).to have_publish_summary(
+        :custom_project_project => { :old => "v1.2.3", :new => "v1.2.4", :bump => :patch }
+      )
       expect(output).to_not include("# Updating package versions"), output
       expect(output).to_not include("Mono error was encountered"), output
 
@@ -230,18 +227,9 @@ RSpec.describe Mono::Cli::Publish do
       project_dir = "/custom_project_project"
       next_version = "1.2.4"
 
-      expect(output).to include(<<~OUTPUT), output
-        The following packages will be published (or not):
-        - custom_project_project:
-          Current version: v1.2.3
-          Next version:    v1.2.4 (patch)
-      OUTPUT
-      expect(output).to include(<<~OUTPUT), output
-        # Updating package versions
-        - custom_project_project:
-          Current version: v1.2.3
-          Next version:    v1.2.4 (patch)
-      OUTPUT
+      expect(output).to has_publish_and_update_summary(
+        :custom_project_project => { :old => "v1.2.3", :new => "v1.2.4", :bump => :patch }
+      )
 
       in_project do
         changelog = File.read("CHANGELOG.md")
@@ -285,18 +273,9 @@ RSpec.describe Mono::Cli::Publish do
       project_dir = "/custom_project_project"
       next_version = "1.2.4.alpha.1"
 
-      expect(output).to include(<<~OUTPUT), output
-        The following packages will be published (or not):
-        - custom_project_project:
-          Current version: v1.2.3
-          Next version:    v1.2.4.alpha.1 (patch)
-      OUTPUT
-      expect(output).to include(<<~OUTPUT), output
-        # Updating package versions
-        - custom_project_project:
-          Current version: v1.2.3
-          Next version:    v1.2.4.alpha.1 (patch)
-      OUTPUT
+      expect(output).to has_publish_and_update_summary(
+        :custom_project_project => { :old => "v1.2.3", :new => "v1.2.4.alpha.1", :bump => :patch }
+      )
 
       in_project do
         expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version}"))
@@ -342,18 +321,13 @@ RSpec.describe Mono::Cli::Publish do
       project_dir = "/#{current_project}"
       next_version = "1.2.3.alpha.2"
 
-      expect(output).to include(<<~OUTPUT), output
-        The following packages will be published (or not):
-        - #{current_project}:
-          Current version: v1.2.3.alpha.1
-          Next version:    v1.2.3.alpha.2 (patch)
-      OUTPUT
-      expect(output).to include(<<~OUTPUT), output
-        # Updating package versions
-        - #{current_project}:
-          Current version: v1.2.3.alpha.1
-          Next version:    v1.2.3.alpha.2 (patch)
-      OUTPUT
+      expect(output).to has_publish_and_update_summary(
+        :custom_project_project => {
+          :old => "v1.2.3.alpha.1",
+          :new => "v1.2.3.alpha.2",
+          :bump => :patch
+        }
+      )
 
       in_project do
         expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version}"))
@@ -401,18 +375,13 @@ RSpec.describe Mono::Cli::Publish do
       project_dir = "/#{current_project}"
       next_version = "1.2.3"
 
-      expect(output).to include(<<~OUTPUT), output
-        The following packages will be published (or not):
-        - #{current_project}:
-          Current version: v1.2.3.alpha.1
-          Next version:    v1.2.3 (patch)
-      OUTPUT
-      expect(output).to include(<<~OUTPUT), output
-        # Updating package versions
-        - #{current_project}:
-          Current version: v1.2.3.alpha.1
-          Next version:    v1.2.3 (patch)
-      OUTPUT
+      expect(output).to has_publish_and_update_summary(
+        :custom_project_project => {
+          :old => "v1.2.3.alpha.1",
+          :new => "v1.2.3",
+          :bump => :patch
+        }
+      )
 
       in_project do
         expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version}"))
@@ -457,18 +426,13 @@ RSpec.describe Mono::Cli::Publish do
       project_dir = "/#{current_project}"
       next_version = "1.2.3"
 
-      expect(output).to include(<<~OUTPUT), output
-        The following packages will be published (or not):
-        - #{current_project}:
-          Current version: v1.2.3.alpha.1
-          Next version:    v1.2.3 (patch)
-      OUTPUT
-      expect(output).to include(<<~OUTPUT), output
-        # Updating package versions
-        - #{current_project}:
-          Current version: v1.2.3.alpha.1
-          Next version:    v1.2.3 (patch)
-      OUTPUT
+      expect(output).to has_publish_and_update_summary(
+        :custom_project_project => {
+          :old => "v1.2.3.alpha.1",
+          :new => "v1.2.3",
+          :bump => :patch
+        }
+      )
 
       in_project do
         expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version}"))

--- a/spec/lib/mono/cli/publish/custom_spec.rb
+++ b/spec/lib/mono/cli/publish/custom_spec.rb
@@ -24,18 +24,9 @@ RSpec.describe Mono::Cli::Publish do
     project_dir = "/#{current_project}"
     next_version = "1.2.3a2"
 
-    expect(output).to include(<<~OUTPUT), output
-      The following packages will be published (or not):
-      - #{current_project}:
-        Current version: v1.2.3a1
-        Next version:    v1.2.3a2 (patch)
-    OUTPUT
-    expect(output).to include(<<~OUTPUT), output
-      # Updating package versions
-      - #{current_project}:
-        Current version: v1.2.3a1
-        Next version:    v1.2.3a2 (patch)
-    OUTPUT
+    expect(output).to has_publish_and_update_summary(
+      current_project => { :old => "v1.2.3a1", :new => "v1.2.3a2", :bump => :patch }
+    )
 
     in_project do
       expect(File.read("version.py")).to include(next_version)

--- a/spec/lib/mono/cli/publish/elixir_spec.rb
+++ b/spec/lib/mono/cli/publish/elixir_spec.rb
@@ -17,18 +17,9 @@ RSpec.describe Mono::Cli::Publish do
       project_dir = "/#{current_project}"
       next_version = "1.2.4"
 
-      expect(output).to include(<<~OUTPUT), output
-        The following packages will be published (or not):
-        - #{current_project}:
-          Current version: v1.2.3
-          Next version:    v1.2.4 (patch)
-      OUTPUT
-      expect(output).to include(<<~OUTPUT), output
-        # Updating package versions
-        - #{current_project}:
-          Current version: v1.2.3
-          Next version:    v1.2.4 (patch)
-      OUTPUT
+      expect(output).to has_publish_and_update_summary(
+        current_project => { :old => "v1.2.3", :new => "v1.2.4", :bump => :patch }
+      )
 
       in_project do
         expect(File.read("mix.exs")).to include(%(version: "#{next_version}",))
@@ -76,18 +67,9 @@ RSpec.describe Mono::Cli::Publish do
       project_dir = "/#{current_project}"
       next_version = "1.2.4"
 
-      expect(output).to include(<<~OUTPUT), output
-        The following packages will be published (or not):
-        - #{current_project}:
-          Current version: v1.2.3
-          Next version:    v1.2.4 (patch)
-      OUTPUT
-      expect(output).to include(<<~OUTPUT), output
-        # Updating package versions
-        - #{current_project}:
-          Current version: v1.2.3
-          Next version:    v1.2.4 (patch)
-      OUTPUT
+      expect(output).to has_publish_and_update_summary(
+        current_project => { :old => "v1.2.3", :new => "v1.2.4", :bump => :patch }
+      )
 
       in_project do
         contents = File.read("mix.exs")
@@ -145,19 +127,10 @@ RSpec.describe Mono::Cli::Publish do
       next_version_a = "1.2.4"
       tag = "package_a@#{next_version_a}"
 
-      expect(output).to include(<<~OUTPUT), output
-        The following packages will be published (or not):
-        - package_a:
-          Current version: package_a@1.2.3
-          Next version:    package_a@1.2.4 (patch)
-        - package_b: (Will not publish)
-      OUTPUT
-      expect(output).to include(<<~OUTPUT), output
-        # Updating package versions
-        - package_a:
-          Current version: package_a@1.2.3
-          Next version:    package_a@1.2.4 (patch)
-      OUTPUT
+      expect(output).to has_publish_and_update_summary(
+        :package_a => { :old => "package_a@1.2.3", :new => "package_a@1.2.4", :bump => :patch },
+        :package_b => :no_publish
+      )
 
       in_project do
         in_package :package_a do
@@ -217,24 +190,10 @@ RSpec.describe Mono::Cli::Publish do
       tag_a = "jason@#{next_version_a}"
       tag_b = "package_b@#{next_version_b}"
 
-      expect(output).to include(<<~OUTPUT), output
-        The following packages will be published (or not):
-        - jason:
-          Current version: jason@1.1.2
-          Next version:    jason@1.1.3 (patch)
-        - package_b:
-          Current version: package_b@2.0.0
-          Next version:    package_b@2.0.1 (patch)
-      OUTPUT
-      expect(output).to include(<<~OUTPUT), output
-        # Updating package versions
-        - jason:
-          Current version: jason@1.1.2
-          Next version:    jason@1.1.3 (patch)
-        - package_b:
-          Current version: package_b@2.0.0
-          Next version:    package_b@2.0.1 (patch)
-      OUTPUT
+      expect(output).to has_publish_and_update_summary(
+        :jason => { :old => "jason@1.1.2", :new => "jason@1.1.3", :bump => :patch },
+        :package_b => { :old => "package_b@2.0.0", :new => "package_b@2.0.1", :bump => :patch }
+      )
 
       in_project do
         in_package :jason do

--- a/spec/lib/mono/cli/publish/nodejs_spec.rb
+++ b/spec/lib/mono/cli/publish/nodejs_spec.rb
@@ -19,18 +19,9 @@ RSpec.describe Mono::Cli::Publish do
         next_version = "1.0.1"
         tag = "v#{next_version}"
 
-        expect(output).to include(<<~OUTPUT), output
-          The following packages will be published (or not):
-          - my_package:
-            Current version: v1.0.0
-            Next version:    v1.0.1 (patch)
-        OUTPUT
-        expect(output).to include(<<~OUTPUT), output
-          # Updating package versions
-          - my_package:
-            Current version: v1.0.0
-            Next version:    v1.0.1 (patch)
-        OUTPUT
+        expect(output).to has_publish_and_update_summary(
+          :my_package => { :old => "v1.0.0", :new => "v1.0.1", :bump => :patch }
+        )
 
         in_project do
           expect(File.read("package.json")).to include(%("version": "#{next_version}"))
@@ -76,18 +67,9 @@ RSpec.describe Mono::Cli::Publish do
         next_version = "1.0.1-alpha.1"
         tag = "v#{next_version}"
 
-        expect(output).to include(<<~OUTPUT), output
-          The following packages will be published (or not):
-          - my_package:
-            Current version: v1.0.0
-            Next version:    v1.0.1-alpha.1 (patch)
-        OUTPUT
-        expect(output).to include(<<~OUTPUT), output
-          # Updating package versions
-          - my_package:
-            Current version: v1.0.0
-            Next version:    v1.0.1-alpha.1 (patch)
-        OUTPUT
+        expect(output).to has_publish_and_update_summary(
+          :my_package => { :old => "v1.0.0", :new => "v1.0.1-alpha.1", :bump => :patch }
+        )
 
         in_project do
           expect(File.read("package.json")).to include(%("version": "#{next_version}"))
@@ -122,18 +104,9 @@ RSpec.describe Mono::Cli::Publish do
         next_version = "1.0.1-beta.1"
         tag = "v#{next_version}"
 
-        expect(output).to include(<<~OUTPUT), output
-          The following packages will be published (or not):
-          - my_package:
-            Current version: v1.0.0
-            Next version:    v1.0.1-beta.1 (patch)
-        OUTPUT
-        expect(output).to include(<<~OUTPUT), output
-          # Updating package versions
-          - my_package:
-            Current version: v1.0.0
-            Next version:    v1.0.1-beta.1 (patch)
-        OUTPUT
+        expect(output).to has_publish_and_update_summary(
+          :my_package => { :old => "v1.0.0", :new => "v1.0.1-beta.1", :bump => :patch }
+        )
 
         in_project do
           expect(File.read("package.json")).to include(%("version": "#{next_version}"))
@@ -169,18 +142,9 @@ RSpec.describe Mono::Cli::Publish do
         next_version = "2.3.2"
         tag = "v#{next_version}"
 
-        expect(output).to include(<<~OUTPUT), output
-          The following packages will be published (or not):
-          - my_package:
-            Current version: v2.3.1
-            Next version:    v2.3.2 (patch)
-        OUTPUT
-        expect(output).to include(<<~OUTPUT), output
-          # Updating package versions
-          - my_package:
-            Current version: v2.3.1
-            Next version:    v2.3.2 (patch)
-        OUTPUT
+        expect(output).to has_publish_and_update_summary(
+          :my_package => { :old => "v2.3.1", :new => "v2.3.2", :bump => :patch }
+        )
 
         in_project do
           expect(File.read("package.json")).to include(%("version": "#{next_version}"))
@@ -215,18 +179,9 @@ RSpec.describe Mono::Cli::Publish do
         next_version = "1.0.1-rc.1"
         tag = "v#{next_version}"
 
-        expect(output).to include(<<~OUTPUT), output
-          The following packages will be published (or not):
-          - my_package:
-            Current version: v1.0.0
-            Next version:    v1.0.1-rc.1 (patch)
-        OUTPUT
-        expect(output).to include(<<~OUTPUT), output
-          # Updating package versions
-          - my_package:
-            Current version: v1.0.0
-            Next version:    v1.0.1-rc.1 (patch)
-        OUTPUT
+        expect(output).to has_publish_and_update_summary(
+          :my_package => { :old => "v1.0.0", :new => "v1.0.1-rc.1", :bump => :patch }
+        )
 
         in_project do
           expect(File.read("package.json")).to include(%("version": "#{next_version}"))
@@ -270,19 +225,14 @@ RSpec.describe Mono::Cli::Publish do
         next_version = "1.0.1"
         tag = "package_one@#{next_version}"
 
-        expect(output).to include(<<~OUTPUT), output
-          The following packages will be published (or not):
-          - package_one:
-            Current version: package_one@1.0.0
-            Next version:    package_one@1.0.1 (patch)
-          - package_two: (Will not publish)
-        OUTPUT
-        expect(output).to include(<<~OUTPUT), output
-          # Updating package versions
-          - package_one:
-            Current version: package_one@1.0.0
-            Next version:    package_one@1.0.1 (patch)
-        OUTPUT
+        expect(output).to has_publish_and_update_summary(
+          :package_one => {
+            :old => "package_one@1.0.0",
+            :new => "package_one@1.0.1",
+            :bump => :patch
+          },
+          :package_two => :no_publish
+        )
 
         in_project do
           in_package "package_one" do
@@ -341,24 +291,18 @@ RSpec.describe Mono::Cli::Publish do
         package_one_tag = "package_one@#{next_version_one}"
         package_two_tag = "package_two@#{next_version_two}"
 
-        expect(output).to include(<<~OUTPUT), output
-          The following packages will be published (or not):
-          - package_one:
-            Current version: package_one@1.0.0
-            Next version:    package_one@1.0.1 (patch)
-          - package_two:
-            Current version: package_two@2.3.4
-            Next version:    package_two@2.3.5 (patch)
-        OUTPUT
-        expect(output).to include(<<~OUTPUT), output
-          # Updating package versions
-          - package_one:
-            Current version: package_one@1.0.0
-            Next version:    package_one@1.0.1 (patch)
-          - package_two:
-            Current version: package_two@2.3.4
-            Next version:    package_two@2.3.5 (patch)
-        OUTPUT
+        expect(output).to has_publish_and_update_summary(
+          :package_one => {
+            :old => "package_one@1.0.0",
+            :new => "package_one@1.0.1",
+            :bump => :patch
+          },
+          :package_two => {
+            :old => "package_two@2.3.4",
+            :new => "package_two@2.3.5",
+            :bump => :patch
+          }
+        )
 
         in_project do
           in_package "package_one" do
@@ -481,30 +425,11 @@ RSpec.describe Mono::Cli::Publish do
         package_tag_b = "package_b@#{next_version_b}"
         package_tag_c = "package_c@#{next_version_c}"
 
-        expect(output).to include(<<~OUTPUT), output
-          The following packages will be published (or not):
-          - package_a:
-            Current version: package_a@1.0.0
-            Next version:    package_a@1.0.1 (patch)
-          - package_b:
-            Current version: package_b@2.3.4
-            Next version:    package_b@2.3.5 (patch)
-          - package_c:
-            Current version: package_c@3.0.9
-            Next version:    package_c@3.0.10 (patch)
-        OUTPUT
-        expect(output).to include(<<~OUTPUT), output
-          # Updating package versions
-          - package_a:
-            Current version: package_a@1.0.0
-            Next version:    package_a@1.0.1 (patch)
-          - package_b:
-            Current version: package_b@2.3.4
-            Next version:    package_b@2.3.5 (patch)
-          - package_c:
-            Current version: package_c@3.0.9
-            Next version:    package_c@3.0.10 (patch)
-        OUTPUT
+        expect(output).to has_publish_and_update_summary(
+          :package_a => { :old => "package_a@1.0.0", :new => "package_a@1.0.1", :bump => :patch },
+          :package_b => { :old => "package_b@2.3.4", :new => "package_b@2.3.5", :bump => :patch },
+          :package_c => { :old => "package_c@3.0.9", :new => "package_c@3.0.10", :bump => :patch }
+        )
 
         in_project do
           in_package :package_a do
@@ -596,24 +521,18 @@ RSpec.describe Mono::Cli::Publish do
         package_tag_a = "package_a@#{next_version_a}"
         package_tag_b = "package_b@#{next_version_b}"
 
-        expect(output).to include(<<~OUTPUT), output
-          The following packages will be published (or not):
-          - package_a:
-            Current version: package_a@1.0.0
-            Next version:    package_a@1.0.1-alpha.1 (patch)
-          - package_b:
-            Current version: package_b@2.3.4
-            Next version:    package_b@2.3.5-alpha.1 (patch)
-        OUTPUT
-        expect(output).to include(<<~OUTPUT), output
-          # Updating package versions
-          - package_a:
-            Current version: package_a@1.0.0
-            Next version:    package_a@1.0.1-alpha.1 (patch)
-          - package_b:
-            Current version: package_b@2.3.4
-            Next version:    package_b@2.3.5-alpha.1 (patch)
-        OUTPUT
+        expect(output).to has_publish_and_update_summary(
+          :package_a => {
+            :old => "package_a@1.0.0",
+            :new => "package_a@1.0.1-alpha.1",
+            :bump => :patch
+          },
+          :package_b => {
+            :old => "package_b@2.3.4",
+            :new => "package_b@2.3.5-alpha.1",
+            :bump => :patch
+          }
+        )
 
         in_project do
           in_package :package_a do
@@ -690,24 +609,18 @@ RSpec.describe Mono::Cli::Publish do
         package_tag_a = "package_a@#{next_version_a}"
         package_tag_b = "package_b@#{next_version_b}"
 
-        expect(output).to include(<<~OUTPUT), output
-          The following packages will be published (or not):
-          - package_a:
-            Current version: package_a@1.0.0
-            Next version:    package_a@1.0.1 (patch)
-          - package_b:
-            Current version: package_b@2.3.4
-            Next version:    package_b@2.3.5 (patch)
-        OUTPUT
-        expect(output).to include(<<~OUTPUT), output
-          # Updating package versions
-          - package_a:
-            Current version: package_a@1.0.0
-            Next version:    package_a@1.0.1 (patch)
-          - package_b:
-            Current version: package_b@2.3.4
-            Next version:    package_b@2.3.5 (patch)
-        OUTPUT
+        expect(output).to has_publish_and_update_summary(
+          :package_a => {
+            :old => "package_a@1.0.0",
+            :new => "package_a@1.0.1",
+            :bump => :patch
+          },
+          :package_b => {
+            :old => "package_b@2.3.4",
+            :new => "package_b@2.3.5",
+            :bump => :patch
+          }
+        )
 
         in_project do
           in_package :package_a do
@@ -778,18 +691,9 @@ RSpec.describe Mono::Cli::Publish do
         next_version = "1.0.1"
         tag = "v#{next_version}"
 
-        expect(output).to include(<<~OUTPUT), output
-          The following packages will be published (or not):
-          - my_package:
-            Current version: v1.0.0
-            Next version:    v1.0.1 (patch)
-        OUTPUT
-        expect(output).to include(<<~OUTPUT), output
-          # Updating package versions
-          - my_package:
-            Current version: v1.0.0
-            Next version:    v1.0.1 (patch)
-        OUTPUT
+        expect(output).to has_publish_and_update_summary(
+          :my_package => { :old => "v1.0.0", :new => "v1.0.1", :bump => :patch }
+        )
 
         in_project do
           expect(File.read("package.json")).to include(%("version": "#{next_version}"))

--- a/spec/lib/mono/cli/publish/ruby_spec.rb
+++ b/spec/lib/mono/cli/publish/ruby_spec.rb
@@ -17,18 +17,9 @@ RSpec.describe Mono::Cli::Publish do
       project_dir = "/#{current_project}"
       next_version = "1.2.4"
 
-      expect(output).to include(<<~OUTPUT), output
-        The following packages will be published (or not):
-        - #{current_project}:
-          Current version: v1.2.3
-          Next version:    v1.2.4 (patch)
-      OUTPUT
-      expect(output).to include(<<~OUTPUT), output
-        # Updating package versions
-        - #{current_project}:
-          Current version: v1.2.3
-          Next version:    v1.2.4 (patch)
-      OUTPUT
+      expect(output).to has_publish_and_update_summary(
+        current_project => { :old => "v1.2.3", :new => "v1.2.4", :bump => :patch }
+      )
 
       in_project do
         expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version}"))
@@ -76,18 +67,9 @@ RSpec.describe Mono::Cli::Publish do
         project_dir = "/#{current_project}"
         next_version = "1.2.4"
 
-        expect(output).to include(<<~OUTPUT), output
-          The following packages will be published (or not):
-          - #{current_project}:
-            Current version: v1.2.3
-            Next version:    v1.2.4 (patch)
-        OUTPUT
-        expect(output).to include(<<~OUTPUT), output
-          # Updating package versions
-          - #{current_project}:
-            Current version: v1.2.3
-            Next version:    v1.2.4 (patch)
-        OUTPUT
+        expect(output).to has_publish_and_update_summary(
+          current_project => { :old => "v1.2.3", :new => "v1.2.4", :bump => :patch }
+        )
 
         in_project do
           expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version}"))
@@ -137,18 +119,9 @@ RSpec.describe Mono::Cli::Publish do
       project_dir = "/#{current_project}"
       next_version = "1.2.4"
 
-      expect(output).to include(<<~OUTPUT), output
-        The following packages will be published (or not):
-        - #{current_project}:
-          Current version: v1.2.3
-          Next version:    v1.2.4 (patch)
-      OUTPUT
-      expect(output).to include(<<~OUTPUT), output
-        # Updating package versions
-        - #{current_project}:
-          Current version: v1.2.3
-          Next version:    v1.2.4 (patch)
-      OUTPUT
+      expect(output).to has_publish_and_update_summary(
+        current_project => { :old => "v1.2.3", :new => "v1.2.4", :bump => :patch }
+      )
 
       in_project do
         expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version}"))
@@ -202,19 +175,10 @@ RSpec.describe Mono::Cli::Publish do
       next_version_a = "1.2.4"
       tag_a = "package_a@#{next_version_a}"
 
-      expect(output).to include(<<~OUTPUT), output
-        The following packages will be published (or not):
-        - package_a:
-          Current version: package_a@1.2.3
-          Next version:    package_a@1.2.4 (patch)
-        - package_b: (Will not publish)
-      OUTPUT
-      expect(output).to include(<<~OUTPUT), output
-        # Updating package versions
-        - package_a:
-          Current version: package_a@1.2.3
-          Next version:    package_a@1.2.4 (patch)
-      OUTPUT
+      expect(output).to has_publish_and_update_summary(
+        :package_a => { :old => "package_a@1.2.3", :new => "package_a@1.2.4", :bump => :patch },
+        :package_b => :no_publish
+      )
 
       in_project do
         in_package :package_a do
@@ -272,24 +236,10 @@ RSpec.describe Mono::Cli::Publish do
       tag_a = "package_a@#{next_version_a}"
       tag_b = "package_b@#{next_version_b}"
 
-      expect(output).to include(<<~OUTPUT), output
-        The following packages will be published (or not):
-        - package_a:
-          Current version: package_a@1.2.3
-          Next version:    package_a@1.2.4 (patch)
-        - package_b:
-          Current version: package_b@2.0.0
-          Next version:    package_b@2.0.1 (patch)
-      OUTPUT
-      expect(output).to include(<<~OUTPUT), output
-        # Updating package versions
-        - package_a:
-          Current version: package_a@1.2.3
-          Next version:    package_a@1.2.4 (patch)
-        - package_b:
-          Current version: package_b@2.0.0
-          Next version:    package_b@2.0.1 (patch)
-      OUTPUT
+      expect(output).to has_publish_and_update_summary(
+        :package_a => { :old => "package_a@1.2.3", :new => "package_a@1.2.4", :bump => :patch },
+        :package_b => { :old => "package_b@2.0.0", :new => "package_b@2.0.1", :bump => :patch }
+      )
 
       in_project do
         in_package :package_a do
@@ -371,30 +321,11 @@ RSpec.describe Mono::Cli::Publish do
       tag_b = "package_b@#{next_version_b}"
       tag_c = "package_c@#{next_version_c}"
 
-      expect(output).to include(<<~OUTPUT), output
-        The following packages will be published (or not):
-        - package_a:
-          Current version: package_a@1.2.3
-          Next version:    package_a@1.2.4 (patch)
-        - package_b:
-          Current version: package_b@2.0.0
-          Next version:    package_b@2.0.1 (patch)
-        - package_c:
-          Current version: package_c@3.3.0
-          Next version:    package_c@3.3.1 (patch)
-      OUTPUT
-      expect(output).to include(<<~OUTPUT), output
-        # Updating package versions
-        - package_a:
-          Current version: package_a@1.2.3
-          Next version:    package_a@1.2.4 (patch)
-        - package_b:
-          Current version: package_b@2.0.0
-          Next version:    package_b@2.0.1 (patch)
-        - package_c:
-          Current version: package_c@3.3.0
-          Next version:    package_c@3.3.1 (patch)
-      OUTPUT
+      expect(output).to has_publish_and_update_summary(
+        :package_a => { :old => "package_a@1.2.3", :new => "package_a@1.2.4", :bump => :patch },
+        :package_b => { :old => "package_b@2.0.0", :new => "package_b@2.0.1", :bump => :patch },
+        :package_c => { :old => "package_c@3.3.0", :new => "package_c@3.3.1", :bump => :patch }
+      )
 
       in_project do
         in_package :package_a do

--- a/spec/support/matchers/publish_summary.rb
+++ b/spec/support/matchers/publish_summary.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :have_publish_summary do |projects|
+  match do |actual|
+    matchers = []
+    Array(projects).each do |project_name, options|
+      matchers <<
+        if options == :no_publish
+          "- #{project_name}: (Will not publish)"
+        else
+          <<~MATCHER
+            - #{project_name}:
+              Current version: #{options[:old]}
+              Next version:    #{options[:new]} (#{options[:bump]})
+          MATCHER
+        end
+    end
+    expect(actual).to include(<<~OUTPUT), actual
+      The following packages will be published (or not):
+      #{matchers.join}
+    OUTPUT
+  end
+end
+
+RSpec::Matchers.define :have_update_summary do |projects|
+  match do |actual|
+    matchers = []
+    Array(projects).each do |project_name, options|
+      matchers <<
+        if options != :no_publish
+          <<~MATCHER
+            - #{project_name}:
+              Current version: #{options[:old]}
+              Next version:    #{options[:new]} (#{options[:bump]})
+          MATCHER
+        end
+    end
+    expect(actual).to include(<<~OUTPUT), actual
+      # Updating package versions
+      #{matchers.compact.join}
+    OUTPUT
+  end
+end
+
+RSpec::Matchers.define :has_publish_and_update_summary do |projects|
+  match do |actual|
+    expect(actual).to have_publish_summary(projects)
+    expect(actual).to have_update_summary(projects)
+  end
+end


### PR DESCRIPTION
We had a lot of repeated content in brittle output matchers, move these to helpers so they take up less space and are easier to update in the future.

[skip changeset]
[skip review]