### PR TITLE
More small test suite refactoring

### DIFF
--- a/spec/lib/mono/changeset_collection_spec.rb
+++ b/spec/lib/mono/changeset_collection_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe Mono::ChangesetCollection do
 
       in_project do
         collection.write_changesets_to_changelog
-        changelog = normalize_changelog(File.read("CHANGELOG.md"))
+        changelog = normalize_changelog(read_changelog_file)
         expect(changelog).to include(<<~CHANGELOG)
           ## 2.0.0
 
@@ -274,7 +274,7 @@ RSpec.describe Mono::ChangesetCollection do
 
       in_project do
         collection.write_changesets_to_changelog
-        changelog = normalize_changelog(File.read("CHANGELOG.md"))
+        changelog = normalize_changelog(read_changelog_file)
         expect(changelog).to include(<<~CHANGELOG)
           ## 2.0.0
 

--- a/spec/lib/mono/cli/publish/base_spec.rb
+++ b/spec/lib/mono/cli/publish/base_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe Mono::Cli::Publish do
         expect(read_ruby_gem_version_file).to have_ruby_version("1.2.3")
         expect(current_package_changeset_files.length).to eql(1)
 
-        changelog = File.read("CHANGELOG.md")
+        changelog = read_changelog_file
         expect(changelog).to_not include("1.2.4")
 
         expect(local_changes?).to be_falsy, local_changes.inspect
@@ -232,7 +232,7 @@ RSpec.describe Mono::Cli::Publish do
       )
 
       in_project do
-        changelog = File.read("CHANGELOG.md")
+        changelog = read_changelog_file
         expect_changelog_to_include_version_header(changelog, next_version)
         expect_changelog_to_include_release_notes(changelog, :patch)
 
@@ -281,7 +281,7 @@ RSpec.describe Mono::Cli::Publish do
         expect(read_ruby_gem_version_file).to have_ruby_version(next_version)
         expect(current_package_changeset_files.length).to eql(0)
 
-        changelog = File.read("CHANGELOG.md")
+        changelog = read_changelog_file
         expect_changelog_to_include_version_header(changelog, next_version)
         expect_changelog_to_include_release_notes(changelog, :patch)
 
@@ -333,7 +333,7 @@ RSpec.describe Mono::Cli::Publish do
         expect(read_ruby_gem_version_file).to have_ruby_version(next_version)
         expect(current_package_changeset_files.length).to eql(0)
 
-        changelog = File.read("CHANGELOG.md")
+        changelog = read_changelog_file
         expect_changelog_to_include_version_header(changelog, next_version)
         expect_changelog_to_include_release_notes(changelog, :patch)
 
@@ -387,7 +387,7 @@ RSpec.describe Mono::Cli::Publish do
         expect(read_ruby_gem_version_file).to have_ruby_version(next_version)
         expect(current_package_changeset_files.length).to eql(0)
 
-        changelog = File.read("CHANGELOG.md")
+        changelog = read_changelog_file
         expect_changelog_to_include_version_header(changelog, next_version)
         expect_changelog_to_include_release_notes(changelog, :patch)
 
@@ -438,7 +438,7 @@ RSpec.describe Mono::Cli::Publish do
         expect(read_ruby_gem_version_file).to have_ruby_version(next_version)
         expect(current_package_changeset_files.length).to eql(0)
 
-        changelog = File.read("CHANGELOG.md")
+        changelog = read_changelog_file
         expect_changelog_to_include_version_header(changelog, next_version)
         expect_changelog_to_include_message(changelog, :patch, "Package release.")
 

--- a/spec/lib/mono/cli/publish/base_spec.rb
+++ b/spec/lib/mono/cli/publish/base_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe Mono::Cli::Publish do
         # Does not commit any changes during the publish process on exit
         expect(commit_count).to eql(original_commit_count)
 
-        expect(File.read("lib/example/version.rb")).to include(%(VERSION = "1.2.3"))
+        expect(read_ruby_gem_version_file).to have_ruby_version("1.2.3")
         expect(current_package_changeset_files.length).to eql(1)
 
         changelog = File.read("CHANGELOG.md")
@@ -278,7 +278,7 @@ RSpec.describe Mono::Cli::Publish do
       )
 
       in_project do
-        expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version}"))
+        expect(read_ruby_gem_version_file).to have_ruby_version(next_version)
         expect(current_package_changeset_files.length).to eql(0)
 
         changelog = File.read("CHANGELOG.md")
@@ -330,7 +330,7 @@ RSpec.describe Mono::Cli::Publish do
       )
 
       in_project do
-        expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version}"))
+        expect(read_ruby_gem_version_file).to have_ruby_version(next_version)
         expect(current_package_changeset_files.length).to eql(0)
 
         changelog = File.read("CHANGELOG.md")
@@ -384,7 +384,7 @@ RSpec.describe Mono::Cli::Publish do
       )
 
       in_project do
-        expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version}"))
+        expect(read_ruby_gem_version_file).to have_ruby_version(next_version)
         expect(current_package_changeset_files.length).to eql(0)
 
         changelog = File.read("CHANGELOG.md")
@@ -435,7 +435,7 @@ RSpec.describe Mono::Cli::Publish do
       )
 
       in_project do
-        expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version}"))
+        expect(read_ruby_gem_version_file).to have_ruby_version(next_version)
         expect(current_package_changeset_files.length).to eql(0)
 
         changelog = File.read("CHANGELOG.md")

--- a/spec/lib/mono/cli/publish/base_spec.rb
+++ b/spec/lib/mono/cli/publish/base_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe Mono::Cli::Publish do
       confirm_publish_package
       output = run_publish(:lang => :ruby)
 
-      project_dir = "/custom_project_project"
+      project_dir = current_project_path
       next_version = "1.2.4"
 
       expect(output).to has_publish_and_update_summary(
@@ -270,7 +270,7 @@ RSpec.describe Mono::Cli::Publish do
       confirm_publish_package
       output = run_publish(["--alpha"], :lang => :ruby)
 
-      project_dir = "/custom_project_project"
+      project_dir = current_project_path
       next_version = "1.2.4.alpha.1"
 
       expect(output).to has_publish_and_update_summary(
@@ -318,7 +318,7 @@ RSpec.describe Mono::Cli::Publish do
       confirm_publish_package
       output = run_publish(["--alpha"], :lang => :ruby)
 
-      project_dir = "/#{current_project}"
+      project_dir = current_project_path
       next_version = "1.2.3.alpha.2"
 
       expect(output).to has_publish_and_update_summary(
@@ -372,7 +372,7 @@ RSpec.describe Mono::Cli::Publish do
       confirm_publish_package
       output = run_publish(:lang => :ruby)
 
-      project_dir = "/#{current_project}"
+      project_dir = current_project_path
       next_version = "1.2.3"
 
       expect(output).to has_publish_and_update_summary(
@@ -423,7 +423,7 @@ RSpec.describe Mono::Cli::Publish do
       confirm_publish_package
       output = run_publish(:lang => :ruby)
 
-      project_dir = "/#{current_project}"
+      project_dir = current_project_path
       next_version = "1.2.3"
 
       expect(output).to has_publish_and_update_summary(
@@ -512,7 +512,7 @@ RSpec.describe Mono::Cli::Publish do
       confirm_publish_package
       output = run_publish(:lang => :ruby)
 
-      project_dir = "/custom_project_project"
+      project_dir = current_project_path
       next_version = "1.2.4"
       expect(performed_commands).to eql([
         [project_dir, "git tag --list v#{next_version}"],
@@ -550,7 +550,7 @@ RSpec.describe Mono::Cli::Publish do
       confirm_publish_package
       output = run_publish(["--package", "package_a"], :lang => :ruby)
 
-      project_dir = "/custom_project_project"
+      project_dir = current_project_path
       package_a_dir = File.join(project_dir, project_package_path(:package_a))
       next_version = "1.2.4"
       tag = "package_a@#{next_version}"
@@ -587,7 +587,7 @@ RSpec.describe Mono::Cli::Publish do
       confirm_publish_package
       output = run_publish(["--package", "package_a,package_b"], :lang => :ruby)
 
-      project_dir = "/custom_project_project"
+      project_dir = current_project_path
       package_a_dir = "#{project_dir}/packages/package_a"
       package_b_dir = "#{project_dir}/packages/package_b"
       next_version = "1.2.4"
@@ -655,7 +655,7 @@ RSpec.describe Mono::Cli::Publish do
         :failed_commands => [/^gem push/]
       )
 
-      project_dir = "/#{current_project}"
+      project_dir = current_project_path
       next_version = "1.2.4"
 
       expect(output).to include(<<~OUTPUT), output
@@ -702,7 +702,7 @@ RSpec.describe Mono::Cli::Publish do
         :failed_commands => [/^gem push/]
       )
 
-      project_dir = "/#{current_project}"
+      project_dir = current_project_path
       next_version = "1.2.4"
 
       expect(output).to include(<<~OUTPUT), output

--- a/spec/lib/mono/cli/publish/custom_spec.rb
+++ b/spec/lib/mono/cli/publish/custom_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Mono::Cli::Publish do
     confirm_publish_package
     output = run_publish(["--alpha"], :lang => :custom)
 
-    project_dir = "/#{current_project}"
+    project_dir = current_project_path
     next_version = "1.2.3a2"
 
     expect(output).to has_publish_and_update_summary(

--- a/spec/lib/mono/cli/publish/custom_spec.rb
+++ b/spec/lib/mono/cli/publish/custom_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Mono::Cli::Publish do
       expect(File.read("version.py")).to include(next_version)
       expect(current_package_changeset_files.length).to eql(0)
 
-      changelog = File.read("CHANGELOG.md")
+      changelog = read_changelog_file
       expect_changelog_to_include_version_header(changelog, next_version)
       expect_changelog_to_include_release_notes(changelog, :patch)
 

--- a/spec/lib/mono/cli/publish/elixir_spec.rb
+++ b/spec/lib/mono/cli/publish/elixir_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Mono::Cli::Publish do
         expect(File.read("mix.exs")).to include(%(version: "#{next_version}",))
         expect(current_package_changeset_files.length).to eql(0)
 
-        changelog = File.read("CHANGELOG.md")
+        changelog = read_changelog_file
         expect_changelog_to_include_version_header(changelog, next_version)
         expect_changelog_to_include_release_notes(changelog, :patch)
 
@@ -77,7 +77,7 @@ RSpec.describe Mono::Cli::Publish do
         expect(contents).to include(%(version: @version,))
         expect(current_package_changeset_files.length).to eql(0)
 
-        changelog = File.read("CHANGELOG.md")
+        changelog = read_changelog_file
         expect_changelog_to_include_version_header(changelog, next_version)
         expect_changelog_to_include_release_notes(changelog, :patch)
 
@@ -137,7 +137,7 @@ RSpec.describe Mono::Cli::Publish do
           expect(File.read("mix.exs")).to include(%(version: "#{next_version_a}",))
           expect(current_package_changeset_files.length).to eql(0)
 
-          changelog = File.read("CHANGELOG.md")
+          changelog = read_changelog_file
           expect_changelog_to_include_version_header(changelog, next_version_a)
           expect_changelog_to_include_release_notes(changelog, :patch)
         end
@@ -200,7 +200,7 @@ RSpec.describe Mono::Cli::Publish do
           expect(File.read("mix.exs")).to include(%(version: "#{next_version_a}",))
           expect(current_package_changeset_files.length).to eql(0)
 
-          changelog = File.read("CHANGELOG.md")
+          changelog = read_changelog_file
           expect_changelog_to_include_version_header(changelog, next_version_a)
           expect_changelog_to_include_release_notes(changelog, :patch)
         end
@@ -209,7 +209,7 @@ RSpec.describe Mono::Cli::Publish do
           expect(File.read("mix.exs")).to include(%(version: "#{next_version_b}",))
           expect(current_package_changeset_files.length).to eql(0)
 
-          changelog = File.read("CHANGELOG.md")
+          changelog = read_changelog_file
           expect_changelog_to_include_version_header(changelog, next_version_b)
           expect_changelog_to_include_package_bump(changelog, "jason", next_version_a)
         end

--- a/spec/lib/mono/cli/publish/elixir_spec.rb
+++ b/spec/lib/mono/cli/publish/elixir_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Mono::Cli::Publish do
       confirm_publish_package
       output = run_publish(:lang => :elixir)
 
-      project_dir = "/#{current_project}"
+      project_dir = current_project_path
       next_version = "1.2.4"
 
       expect(output).to has_publish_and_update_summary(
@@ -64,7 +64,7 @@ RSpec.describe Mono::Cli::Publish do
       confirm_publish_package
       output = run_publish(:lang => :elixir)
 
-      project_dir = "/#{current_project}"
+      project_dir = current_project_path
       next_version = "1.2.4"
 
       expect(output).to has_publish_and_update_summary(
@@ -121,7 +121,7 @@ RSpec.describe Mono::Cli::Publish do
       confirm_publish_package
       output = run_publish(:lang => :elixir)
 
-      project_dir = "/#{current_project}"
+      project_dir = current_project_path
       package_dir_a = "#{project_dir}/packages/package_a"
       package_dir_b = "#{project_dir}/packages/package_b"
       next_version_a = "1.2.4"
@@ -182,7 +182,7 @@ RSpec.describe Mono::Cli::Publish do
       confirm_publish_package
       output = run_publish(:lang => :elixir)
 
-      project_dir = "/#{current_project}"
+      project_dir = current_project_path
       package_dir_a = "#{project_dir}/packages/jason"
       package_dir_b = "#{project_dir}/packages/package_b"
       next_version_a = "1.1.3"

--- a/spec/lib/mono/cli/publish/nodejs_spec.rb
+++ b/spec/lib/mono/cli/publish/nodejs_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Mono::Cli::Publish do
         confirm_publish_package
         output = run_publish(:lang => :nodejs)
 
-        project_dir = "/#{current_project}"
+        project_dir = current_project_path
         next_version = "1.0.1"
         tag = "v#{next_version}"
 
@@ -63,7 +63,7 @@ RSpec.describe Mono::Cli::Publish do
         confirm_publish_package
         output = run_publish(["--alpha"], :lang => :nodejs)
 
-        project_dir = "/#{current_project}"
+        project_dir = current_project_path
         next_version = "1.0.1-alpha.1"
         tag = "v#{next_version}"
 
@@ -100,7 +100,7 @@ RSpec.describe Mono::Cli::Publish do
         confirm_publish_package
         output = run_publish(["--beta"], :lang => :nodejs)
 
-        project_dir = "/#{current_project}"
+        project_dir = current_project_path
         next_version = "1.0.1-beta.1"
         tag = "v#{next_version}"
 
@@ -138,7 +138,7 @@ RSpec.describe Mono::Cli::Publish do
         package_tag = "2.x-stable"
         output = run_publish(["--tag", package_tag], :lang => :nodejs)
 
-        project_dir = "/#{current_project}"
+        project_dir = current_project_path
         next_version = "2.3.2"
         tag = "v#{next_version}"
 
@@ -175,7 +175,7 @@ RSpec.describe Mono::Cli::Publish do
         confirm_publish_package
         output = run_publish(["--rc"], :lang => :nodejs)
 
-        project_dir = "/#{current_project}"
+        project_dir = current_project_path
         next_version = "1.0.1-rc.1"
         tag = "v#{next_version}"
 
@@ -219,7 +219,7 @@ RSpec.describe Mono::Cli::Publish do
         confirm_publish_package
         output = run_publish(:lang => :nodejs)
 
-        project_dir = "/#{current_project}"
+        project_dir = current_project_path
         package_one_dir = "#{project_dir}/packages/package_one"
         package_two_dir = "#{project_dir}/packages/package_two"
         next_version = "1.0.1"
@@ -283,7 +283,7 @@ RSpec.describe Mono::Cli::Publish do
         confirm_publish_package
         output = run_publish(:lang => :nodejs)
 
-        project_dir = "/#{current_project}"
+        project_dir = current_project_path
         package_one_dir = "#{project_dir}/packages/package_one"
         package_two_dir = "#{project_dir}/packages/package_two"
         next_version_one = "1.0.1"
@@ -414,7 +414,7 @@ RSpec.describe Mono::Cli::Publish do
         confirm_publish_package
         output = run_publish(:lang => :nodejs)
 
-        project_dir = "/#{current_project}"
+        project_dir = current_project_path
         package_dir_a = "#{project_dir}/packages/package_a"
         package_dir_b = "#{project_dir}/packages/package_b"
         package_dir_c = "#{project_dir}/packages/package_c"
@@ -513,7 +513,7 @@ RSpec.describe Mono::Cli::Publish do
         confirm_publish_package
         output = run_publish(["--alpha"], :lang => :nodejs)
 
-        project_dir = "/#{current_project}"
+        project_dir = current_project_path
         package_dir_a = "#{project_dir}/packages/package_a"
         package_dir_b = "#{project_dir}/packages/package_b"
         next_version_a = "1.0.1-alpha.1"
@@ -601,7 +601,7 @@ RSpec.describe Mono::Cli::Publish do
         confirm_publish_package
         output = run_publish(:lang => :nodejs)
 
-        project_dir = "/#{current_project}"
+        project_dir = current_project_path
         package_dir_a = "#{project_dir}/packages/package_a"
         package_dir_b = "#{project_dir}/packages/package_b"
         next_version_a = "1.0.1"
@@ -687,7 +687,7 @@ RSpec.describe Mono::Cli::Publish do
         confirm_publish_package
         output = run_publish(:lang => :nodejs)
 
-        project_dir = "/#{current_project}"
+        project_dir = current_project_path
         next_version = "1.0.1"
         tag = "v#{next_version}"
 

--- a/spec/lib/mono/cli/publish/nodejs_spec.rb
+++ b/spec/lib/mono/cli/publish/nodejs_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Mono::Cli::Publish do
         in_project do
           expect(File.read("package.json")).to include(%("version": "#{next_version}"))
 
-          changelog = File.read("CHANGELOG.md")
+          changelog = read_changelog_file
           expect_changelog_to_include_version_header(changelog, next_version)
           expect_changelog_to_include_release_notes(changelog, :patch)
 
@@ -238,7 +238,7 @@ RSpec.describe Mono::Cli::Publish do
           in_package "package_one" do
             expect(File.read("package.json")).to include(%("version": "#{next_version}"))
 
-            changelog = File.read("CHANGELOG.md")
+            changelog = read_changelog_file
             expect_changelog_to_include_version_header(changelog, next_version)
             expect_changelog_to_include_release_notes(changelog, :patch)
           end
@@ -309,7 +309,7 @@ RSpec.describe Mono::Cli::Publish do
             package_json = JSON.parse(File.read("package.json"))
             expect(package_json["version"]).to eql(next_version_one)
 
-            changelog = File.read("CHANGELOG.md")
+            changelog = read_changelog_file
             expect_changelog_to_include_version_header(changelog, next_version_one)
             expect_changelog_to_include_release_notes(changelog, :patch)
           end
@@ -318,7 +318,7 @@ RSpec.describe Mono::Cli::Publish do
             package_json = JSON.parse(File.read("package.json"))
             expect(package_json["version"]).to eql(next_version_two)
 
-            changelog = File.read("CHANGELOG.md")
+            changelog = read_changelog_file
             expect_changelog_to_include_version_header(changelog, next_version_two)
             expect_changelog_to_include_release_notes(changelog, :patch)
           end
@@ -377,7 +377,7 @@ RSpec.describe Mono::Cli::Publish do
             package_json = JSON.parse(File.read("package.json"))
             expect(package_json["version"]).to eql(next_version_a)
 
-            changelog = File.read("CHANGELOG.md")
+            changelog = read_changelog_file
             expect_changelog_to_include_version_header(changelog, next_version_a)
             expect_changelog_to_include_release_notes(changelog, :patch)
 
@@ -436,7 +436,7 @@ RSpec.describe Mono::Cli::Publish do
             package_json = JSON.parse(File.read("package.json"))
             expect(package_json["version"]).to eql(next_version_a)
 
-            changelog = File.read("CHANGELOG.md")
+            changelog = read_changelog_file
             expect_changelog_to_include_version_header(changelog, next_version_a)
             expect_changelog_to_include_release_notes(changelog, :patch)
           end
@@ -446,7 +446,7 @@ RSpec.describe Mono::Cli::Publish do
             expect(package_json["version"]).to eql(next_version_b)
             expect(package_json["dependencies"]["package_a"]).to eql("=#{next_version_a}")
 
-            changelog = File.read("CHANGELOG.md")
+            changelog = read_changelog_file
             expect_changelog_to_include_version_header(changelog, next_version_b)
             expect_changelog_to_include_package_bump(changelog, :package_a, next_version_a)
           end
@@ -456,7 +456,7 @@ RSpec.describe Mono::Cli::Publish do
             expect(package_json["version"]).to eql(next_version_c)
             expect(package_json["dependencies"]["package_b"]).to eql("=#{next_version_b}")
 
-            changelog = File.read("CHANGELOG.md")
+            changelog = read_changelog_file
             expect_changelog_to_include_version_header(changelog, next_version_c)
             expect_changelog_to_include_package_bump(changelog, :package_b, next_version_b)
           end
@@ -539,7 +539,7 @@ RSpec.describe Mono::Cli::Publish do
             package_json = JSON.parse(File.read("package.json"))
             expect(package_json["version"]).to eql(next_version_a)
 
-            changelog = File.read("CHANGELOG.md")
+            changelog = read_changelog_file
             expect_changelog_to_include_version_header(changelog, next_version_a)
             expect_changelog_to_include_release_notes(changelog, :patch)
           end
@@ -549,7 +549,7 @@ RSpec.describe Mono::Cli::Publish do
             expect(package_json["version"]).to eql(next_version_b)
             expect(package_json["dependencies"]["package_a"]).to eql("=#{next_version_a}")
 
-            changelog = File.read("CHANGELOG.md")
+            changelog = read_changelog_file
             expect_changelog_to_include_version_header(changelog, next_version_b)
             expect_changelog_to_include_package_bump(changelog, :package_a, next_version_a)
           end
@@ -627,7 +627,7 @@ RSpec.describe Mono::Cli::Publish do
             package_json = JSON.parse(File.read("package.json"))
             expect(package_json["version"]).to eql(next_version_a)
 
-            changelog = File.read("CHANGELOG.md")
+            changelog = read_changelog_file
             expect_changelog_to_include_version_header(changelog, next_version_a)
             expect_changelog_to_include_release_notes(changelog, :patch)
           end
@@ -637,7 +637,7 @@ RSpec.describe Mono::Cli::Publish do
             expect(package_json["version"]).to eql(next_version_b)
             expect(package_json["dependencies"]["package_a"]).to eql("=#{next_version_a}")
 
-            changelog = File.read("CHANGELOG.md")
+            changelog = read_changelog_file
             expect_changelog_to_include_version_header(changelog, next_version_b)
             expect_changelog_to_include_package_bump(changelog, :package_a, next_version_a)
           end
@@ -698,7 +698,7 @@ RSpec.describe Mono::Cli::Publish do
         in_project do
           expect(File.read("package.json")).to include(%("version": "#{next_version}"))
 
-          changelog = File.read("CHANGELOG.md")
+          changelog = read_changelog_file
           expect_changelog_to_include_version_header(changelog, next_version)
           expect_changelog_to_include_release_notes(changelog, :patch)
 

--- a/spec/lib/mono/cli/publish/ruby_spec.rb
+++ b/spec/lib/mono/cli/publish/ruby_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Mono::Cli::Publish do
         expect(read_ruby_gem_version_file).to have_ruby_version(next_version)
         expect(current_package_changeset_files.length).to eql(0)
 
-        changelog = File.read("CHANGELOG.md")
+        changelog = read_changelog_file
         expect_changelog_to_include_version_header(changelog, next_version)
         expect_changelog_to_include_release_notes(changelog, :patch)
 
@@ -75,7 +75,7 @@ RSpec.describe Mono::Cli::Publish do
           expect(read_ruby_gem_version_file).to have_ruby_version(next_version)
           expect(current_package_changeset_files.length).to eql(0)
 
-          changelog = File.read("CHANGELOG.md")
+          changelog = read_changelog_file
           expect_changelog_to_include_version_header(changelog, next_version)
           expect_changelog_to_include_release_notes(changelog, :patch)
 
@@ -127,7 +127,7 @@ RSpec.describe Mono::Cli::Publish do
         expect(read_ruby_gem_version_file).to have_ruby_version(next_version)
         expect(current_package_changeset_files.length).to eql(0)
 
-        changelog = File.read("CHANGELOG.md")
+        changelog = read_changelog_file
         expect_changelog_to_include_version_header(changelog, next_version)
         expect_changelog_to_include_release_notes(changelog, :patch)
 
@@ -185,7 +185,7 @@ RSpec.describe Mono::Cli::Publish do
           expect(read_ruby_gem_version_file).to have_ruby_version(next_version_a)
           expect(current_package_changeset_files.length).to eql(0)
 
-          changelog = File.read("CHANGELOG.md")
+          changelog = read_changelog_file
           expect_changelog_to_include_version_header(changelog, next_version_a)
           expect_changelog_to_include_release_notes(changelog, :patch)
         end
@@ -246,7 +246,7 @@ RSpec.describe Mono::Cli::Publish do
           expect(read_ruby_gem_version_file).to have_ruby_version(next_version_a)
           expect(current_package_changeset_files.length).to eql(0)
 
-          changelog = File.read("CHANGELOG.md")
+          changelog = read_changelog_file
           expect_changelog_to_include_version_header(changelog, next_version_a)
           expect_changelog_to_include_release_notes(changelog, :patch)
         end
@@ -255,7 +255,7 @@ RSpec.describe Mono::Cli::Publish do
           expect(read_ruby_gem_version_file).to have_ruby_version(next_version_b)
           expect(current_package_changeset_files.length).to eql(0)
 
-          changelog = File.read("CHANGELOG.md")
+          changelog = read_changelog_file
           expect_changelog_to_include_version_header(changelog, next_version_b)
           expect_changelog_to_include_release_notes(changelog, :patch)
         end
@@ -332,7 +332,7 @@ RSpec.describe Mono::Cli::Publish do
           expect(read_ruby_gem_version_file).to have_ruby_version(next_version_a)
           expect(current_package_changeset_files.length).to eql(0)
 
-          changelog = File.read("CHANGELOG.md")
+          changelog = read_changelog_file
           expect_changelog_to_include_version_header(changelog, next_version_a)
           expect_changelog_to_include_release_notes(changelog, :patch)
         end
@@ -341,7 +341,7 @@ RSpec.describe Mono::Cli::Publish do
           expect(read_ruby_gem_version_file).to have_ruby_version(next_version_b)
           expect(current_package_changeset_files.length).to eql(0)
 
-          changelog = File.read("CHANGELOG.md")
+          changelog = read_changelog_file
           expect_changelog_to_include_version_header(changelog, next_version_b)
           expect_changelog_to_include_package_bump(changelog, "package_a", next_version_a)
         end
@@ -350,7 +350,7 @@ RSpec.describe Mono::Cli::Publish do
           expect(read_ruby_gem_version_file).to have_ruby_version(next_version_c)
           expect(current_package_changeset_files.length).to eql(0)
 
-          changelog = File.read("CHANGELOG.md")
+          changelog = read_changelog_file
           expect_changelog_to_include_version_header(changelog, next_version_c)
           expect_changelog_to_include_package_bump(changelog, "package_b", next_version_b)
         end

--- a/spec/lib/mono/cli/publish/ruby_spec.rb
+++ b/spec/lib/mono/cli/publish/ruby_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Mono::Cli::Publish do
       )
 
       in_project do
-        expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version}"))
+        expect(read_ruby_gem_version_file).to have_ruby_version(next_version)
         expect(current_package_changeset_files.length).to eql(0)
 
         changelog = File.read("CHANGELOG.md")
@@ -72,7 +72,7 @@ RSpec.describe Mono::Cli::Publish do
         )
 
         in_project do
-          expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version}"))
+          expect(read_ruby_gem_version_file).to have_ruby_version(next_version)
           expect(current_package_changeset_files.length).to eql(0)
 
           changelog = File.read("CHANGELOG.md")
@@ -124,7 +124,7 @@ RSpec.describe Mono::Cli::Publish do
       )
 
       in_project do
-        expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version}"))
+        expect(read_ruby_gem_version_file).to have_ruby_version(next_version)
         expect(current_package_changeset_files.length).to eql(0)
 
         changelog = File.read("CHANGELOG.md")
@@ -182,7 +182,7 @@ RSpec.describe Mono::Cli::Publish do
 
       in_project do
         in_package :package_a do
-          expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version_a}"))
+          expect(read_ruby_gem_version_file).to have_ruby_version(next_version_a)
           expect(current_package_changeset_files.length).to eql(0)
 
           changelog = File.read("CHANGELOG.md")
@@ -243,7 +243,7 @@ RSpec.describe Mono::Cli::Publish do
 
       in_project do
         in_package :package_a do
-          expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version_a}"))
+          expect(read_ruby_gem_version_file).to have_ruby_version(next_version_a)
           expect(current_package_changeset_files.length).to eql(0)
 
           changelog = File.read("CHANGELOG.md")
@@ -252,7 +252,7 @@ RSpec.describe Mono::Cli::Publish do
         end
 
         in_package :package_b do
-          expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version_b}"))
+          expect(read_ruby_gem_version_file).to have_ruby_version(next_version_b)
           expect(current_package_changeset_files.length).to eql(0)
 
           changelog = File.read("CHANGELOG.md")
@@ -329,7 +329,7 @@ RSpec.describe Mono::Cli::Publish do
 
       in_project do
         in_package :package_a do
-          expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version_a}"))
+          expect(read_ruby_gem_version_file).to have_ruby_version(next_version_a)
           expect(current_package_changeset_files.length).to eql(0)
 
           changelog = File.read("CHANGELOG.md")
@@ -338,7 +338,7 @@ RSpec.describe Mono::Cli::Publish do
         end
 
         in_package :package_b do
-          expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version_b}"))
+          expect(read_ruby_gem_version_file).to have_ruby_version(next_version_b)
           expect(current_package_changeset_files.length).to eql(0)
 
           changelog = File.read("CHANGELOG.md")
@@ -347,7 +347,7 @@ RSpec.describe Mono::Cli::Publish do
         end
 
         in_package :package_c do
-          expect(File.read("lib/example/version.rb")).to include(%(VERSION = "#{next_version_c}"))
+          expect(read_ruby_gem_version_file).to have_ruby_version(next_version_c)
           expect(current_package_changeset_files.length).to eql(0)
 
           changelog = File.read("CHANGELOG.md")

--- a/spec/lib/mono/cli/publish/ruby_spec.rb
+++ b/spec/lib/mono/cli/publish/ruby_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Mono::Cli::Publish do
       confirm_publish_package
       output = run_publish(:lang => :ruby)
 
-      project_dir = "/#{current_project}"
+      project_dir = current_project_path
       next_version = "1.2.4"
 
       expect(output).to has_publish_and_update_summary(
@@ -64,7 +64,7 @@ RSpec.describe Mono::Cli::Publish do
         confirm_publish_package
         output = run_publish(:lang => :ruby)
 
-        project_dir = "/#{current_project}"
+        project_dir = current_project_path
         next_version = "1.2.4"
 
         expect(output).to has_publish_and_update_summary(
@@ -116,7 +116,7 @@ RSpec.describe Mono::Cli::Publish do
       confirm_publish_package
       output = run_publish(:lang => :ruby)
 
-      project_dir = "/#{current_project}"
+      project_dir = current_project_path
       next_version = "1.2.4"
 
       expect(output).to has_publish_and_update_summary(
@@ -170,7 +170,7 @@ RSpec.describe Mono::Cli::Publish do
       confirm_publish_package
       output = run_publish(:lang => :ruby)
 
-      project_dir = "/#{current_project}"
+      project_dir = current_project_path
       package_dir_a = "#{project_dir}/packages/package_a"
       next_version_a = "1.2.4"
       tag_a = "package_a@#{next_version_a}"
@@ -228,7 +228,7 @@ RSpec.describe Mono::Cli::Publish do
       confirm_publish_package
       output = run_publish(:lang => :ruby)
 
-      project_dir = "/#{current_project}"
+      project_dir = current_project_path
       package_dir_a = "#{project_dir}/packages/package_a"
       package_dir_b = "#{project_dir}/packages/package_b"
       next_version_a = "1.2.4"
@@ -310,7 +310,7 @@ RSpec.describe Mono::Cli::Publish do
       confirm_publish_package
       output = run_publish(:lang => :ruby)
 
-      project_dir = "/#{current_project}"
+      project_dir = current_project_path
       package_dir_a = "#{project_dir}/packages/package_a"
       package_dir_b = "#{project_dir}/packages/package_b"
       package_dir_c = "#{project_dir}/packages/package_c"

--- a/spec/support/helpers/project_helper.rb
+++ b/spec/support/helpers/project_helper.rb
@@ -359,4 +359,8 @@ module ProjectHelper
   def read_ruby_gem_version_file
     File.read("lib/example/version.rb")
   end
+
+  def read_changelog_file
+    File.read("CHANGELOG.md")
+  end
 end

--- a/spec/support/helpers/project_helper.rb
+++ b/spec/support/helpers/project_helper.rb
@@ -24,7 +24,11 @@ module ProjectHelper
     @current_project = project
   end
 
-  def current_project_dir
+  def current_project_path
+    "/#{current_project}"
+  end
+
+  def current_project_path_in_spec_dir
     File.join(EXAMPLES_TMP_DIR, current_project)
   end
 
@@ -41,7 +45,7 @@ module ProjectHelper
     select_project "custom_project"
     prepare_tmp_examples_dir
     # Create new directory
-    FileUtils.mkdir_p current_project_dir
+    FileUtils.mkdir_p current_project_path_in_spec_dir
     init_project
     if block_given?
       in_project do
@@ -80,7 +84,7 @@ module ProjectHelper
 
   def in_project(&block)
     # Execute block in test dir
-    Dir.chdir(current_project_dir, &block)
+    Dir.chdir(current_project_path_in_spec_dir, &block)
   rescue SystemExit => error
     Testing.exit_status = error.status
   end
@@ -90,7 +94,7 @@ module ProjectHelper
     # Create tmp examples dir
     FileUtils.mkdir_p(EXAMPLES_TMP_DIR)
     # Remove existing test dir
-    project_dir = current_project_dir
+    project_dir = current_project_path_in_spec_dir
     # Remove existing project dir if it exists
     FileUtils.rm_r(project_dir) if Dir.exist?(project_dir)
   end
@@ -153,7 +157,7 @@ module ProjectHelper
   end
 
   def package_path(package)
-    File.join(current_project_dir, "packages", package)
+    File.join(current_project_path_in_spec_dir, "packages", package)
   end
 
   def create_changelog

--- a/spec/support/helpers/project_helper.rb
+++ b/spec/support/helpers/project_helper.rb
@@ -355,4 +355,8 @@ module ProjectHelper
     package_json = File.join(Dir.pwd, "package.json")
     File.write(package_json, JSON.dump(new_config))
   end
+
+  def read_ruby_gem_version_file
+    File.read("lib/example/version.rb")
+  end
 end

--- a/spec/support/matchers/package_version.rb
+++ b/spec/support/matchers/package_version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :have_ruby_version do |version|
+  match do |actual|
+    expect(actual).to include(%(VERSION = "#{version}"))
+  end
+end


### PR DESCRIPTION
## Refactor matcher for Ruby gem version

Use a helper to read the version file and a matcher to assert the contents. Better maintainable than copying it every time for every spec.

## Add helper to read the CHANGELOG file

Easier to maintain than having the `File.read` call with the path repeated in every spec.

## Add helper for current project path

Don't build this path in every spec. Instead use this `current_project_path` helper.
