### PR TITLE
Add publish CLI options

### DIFF
--- a/.changesets/add-publish---no-git-option.md
+++ b/.changesets/add-publish---no-git-option.md
@@ -1,0 +1,6 @@
+---
+bump: "minor"
+type: "add"
+---
+
+Add mono publish `--no-git` flag. When this flag is given to `mono publish`, the publishing process will not commit the changes to Git, create a tag or push the changes to the remote. This can be useful when you want mono to only generate changelogs and update package version.

--- a/.changesets/add-publish---no-package-push-option.md
+++ b/.changesets/add-publish---no-package-push-option.md
@@ -1,0 +1,6 @@
+---
+bump: "minor"
+type: "add"
+---
+
+Add mono publish `--no-package-push` flag. When this flag is given to `mono publish`, the publishing process will not push the packages to their version managers. This can be useful when you want mono to only generate changelogs and update package version.

--- a/.changesets/add-publish---yes-flag.md
+++ b/.changesets/add-publish---yes-flag.md
@@ -1,0 +1,6 @@
+---
+bump: "minor"
+type: "add"
+---
+
+Add mono publish `--yes` flag. When this flag is given to `mono publish`, the publishing process will not prompt to confirm publishing. Any OTP prompts by the package managers may still prompt for input.

--- a/lib/mono/cli.rb
+++ b/lib/mono/cli.rb
@@ -270,7 +270,7 @@ module Mono
 
       def publish_options
         params = {}
-        OptionParser.new do |opts|
+        OptionParser.new do |opts| # rubocop:disable Metrics/BlockLength
           opts.banner = "Usage: mono publish [options]"
 
           opts.on "-p", "--package package1,package2,package3", Array,
@@ -289,6 +289,10 @@ module Mono
           opts.on "--tag TAG",
             "Set the tag for the package release (Node.js only)" do |tag|
             params[:tag] = tag
+          end
+          opts.on "--no-git",
+            "Do not commit changes, create a tag and push release using Git" do
+            params[:git] = false
           end
         end.parse(@options)
         params

--- a/lib/mono/cli.rb
+++ b/lib/mono/cli.rb
@@ -273,6 +273,9 @@ module Mono
         OptionParser.new do |opts| # rubocop:disable Metrics/BlockLength
           opts.banner = "Usage: mono publish [options]"
 
+          opts.on "--yes", "Publish packages without confirmation" do |_value|
+            params[:ask_for_confirmation] = false
+          end
           opts.on "-p", "--package package1,package2,package3", Array,
             "Select packages to publish" do |value|
             params[:packages] = value

--- a/lib/mono/cli.rb
+++ b/lib/mono/cli.rb
@@ -294,6 +294,10 @@ module Mono
             "Do not commit changes, create a tag and push release using Git" do
             params[:git] = false
           end
+          opts.on "--no-package-push",
+            "Do not push the release to the package manager registery" do
+            params[:package_push] = false
+          end
         end.parse(@options)
         params
       end

--- a/lib/mono/cli/publish.rb
+++ b/lib/mono/cli/publish.rb
@@ -53,7 +53,7 @@ module Mono
 
         print_summary(packages)
         puts
-        ask_for_publish_confirmation
+        ask_for_publish_confirmation if ask_for_confirmation?
         puts
 
         rollback = []
@@ -81,6 +81,10 @@ module Mono
       end
 
       private
+
+      def ask_for_confirmation?
+        options.fetch(:ask_for_confirmation, true)
+      end
 
       def git?
         options.fetch(:git, true)

--- a/lib/mono/cli/publish.rb
+++ b/lib/mono/cli/publish.rb
@@ -67,7 +67,7 @@ module Mono
           puts
           commit_changes(changed_packages, rollback) if git?
           puts
-          publish_package_manager(changed_packages)
+          publish_package_manager(changed_packages) if package_push?
         rescue => error
           puts
           ask_for_rollback_confirmation(error)
@@ -84,6 +84,10 @@ module Mono
 
       def git?
         options.fetch(:git, true)
+      end
+
+      def package_push?
+        options.fetch(:package_push, true)
       end
 
       def ask_for_publish_confirmation

--- a/spec/lib/mono/cli/publish/base_spec.rb
+++ b/spec/lib/mono/cli/publish/base_spec.rb
@@ -742,4 +742,28 @@ RSpec.describe Mono::Cli::Publish do
       expect(exit_status).to eql(1), output
     end
   end
+
+  context "with --no-git" do
+    it "doesn't commit or push using Git" do
+      prepare_ruby_project do
+        create_ruby_package_files :name => "mygem", :version => "1.2.3"
+        add_changeset :patch
+      end
+      confirm_publish_package
+      output = run_publish(["--no-git"], :lang => :ruby)
+
+      project_dir = current_project_path
+      next_version = "1.2.4"
+
+      in_project do
+        expect(local_changes?).to be_truthy, local_changes.inspect
+      end
+
+      expect(performed_commands).to eql([
+        [project_dir, "gem build"],
+        [project_dir, "gem push mygem-#{next_version}.gem"]
+      ])
+      expect(exit_status).to eql(0), output
+    end
+  end
 end


### PR DESCRIPTION
## Add mono publish --no-git flag

To make it easier to publish our agent, add this option to mono publish so that our publish script in the agent repository can continue doing all the work in Git, and it can wrap mono instead.

## Add mono publish --no-package-push flag

To make it easier to publish our agent, add this option to mono publish so that our publish script in the agent repository can continue doing all the work to upload the release packages, and it can wrap mono instead.

## Add mono publish --yes flag

To make it easier to publish our agent, add this option to mono publish to run mono publish without user interaction. This is useful when you want to call mono from another script or non-interactive environment.

---

I thought about adding a new CLI command just for the changelog generation and package version updating. That requires a bunch of refactoring of the CLI and adding more tests to also cover all the scenarios in that new subcommand. This is a smaller change.

Closes #48
