### PR TITLE
Make changeset creation prompt more consistent

### DIFF
--- a/.changesets/use-selection-prompt-for-change-in-mono-changeset-add.md
+++ b/.changesets/use-selection-prompt-for-change-in-mono-changeset-add.md
@@ -1,0 +1,6 @@
+---
+bump: "minor"
+type: "change"
+---
+
+Use a selection prompt for the semver change in `mono changeset add`. The prompts were inconsistency asking between a number and text input. It now will only require you to select options with numbers.

--- a/lib/mono/changeset.rb
+++ b/lib/mono/changeset.rb
@@ -17,7 +17,11 @@ module Mono
     }.freeze
     # Supported changeset version bumps, sorted by biggest change. The "major"
     # change being the largest, index 0, and patch being the lowest, index 2.
-    SUPPORTED_BUMPS = %w[major minor patch].freeze
+    SUPPORTED_BUMPS = {
+      "major" => "Major",
+      "minor" => "Minor",
+      "patch" => "Patch"
+    }.freeze
     YAML_FRONT_MATTER_REGEXP =
       /\A(---\s*\n.*?\n?)^((---|\.\.\.)\s*$\n?)/m
 
@@ -127,7 +131,7 @@ module Mono
     # - minor == 1
     # - patch == 2
     def bump_index
-      SUPPORTED_BUMPS.index @metadata["bump"]
+      SUPPORTED_BUMPS.keys.index @metadata["bump"]
     end
 
     def date

--- a/lib/mono/cli/changeset/add.rb
+++ b/lib/mono/cli/changeset/add.rb
@@ -66,33 +66,35 @@ module Mono
         def prompt_for_type
           types = Mono::Changeset::SUPPORTED_TYPES.to_a
           loop do
-            puts "What type of change is this: "
-
-            types.each_with_index do |(_value, label), index|
-              puts "#{index + 1}: #{label}"
-            end
-            type_index = required_input("Select type 1-#{types.length}: ")
-            type_index = parse_number(type_index)
-            if type_index&.positive?
-              type = types[type_index - 1]&.first
-              break type if type
-            end
+            puts "What type of change is this?"
+            type = prompt_options("Select change type", types)
+            return type if type
 
             puts "Unknown type selected. Please select a type."
           end
         end
 
         def prompt_for_bump
+          bumps = Mono::Changeset::SUPPORTED_BUMPS.to_a
           loop do
-            input = required_input(
-              "What type of semver bump is this (major/minor/patch): "
-            )
-            if Mono::Changeset.supported_bump?(input)
-              break input
-            else
-              puts "Unknown bump type `#{input}`. " \
-                "Please specify supported bump type."
-            end
+            puts "What type of semver bump is this?"
+            bump = prompt_options("Select bump", bumps)
+            return bump if bump
+
+            puts "Unknown bump type `#{bump}`. " \
+              "Please select a supported bump type."
+          end
+        end
+
+        def prompt_options(prompt, options)
+          options.each_with_index do |(_value, label), index|
+            puts "#{index + 1}: #{label}"
+          end
+          option_index = required_input("#{prompt} 1-#{options.length}: ")
+          option_index = parse_number(option_index)
+          if option_index&.positive?
+            option = options[option_index - 1]&.first
+            return option if option
           end
         end
 

--- a/spec/lib/mono/cli/changeset/add_spec.rb
+++ b/spec/lib/mono/cli/changeset/add_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Mono::Cli::Changeset do
         prepare_project :elixir_single
 
         add_cli_input "My:; Awes/o\\me pa.tch"
-        add_cli_input "1"
-        add_cli_input "patch"
+        add_cli_input "1" # Type: Added
+        add_cli_input "3" # Bump: Patch
         add_cli_input "n"
         output =
           capture_stdout do
@@ -22,7 +22,6 @@ RSpec.describe Mono::Cli::Changeset do
         changeset_path = ".changesets/my---awes-o-me-pa-tch.md"
         expect(output).to include(
           "Summarize the change (for changeset filename):",
-          "What type of semver bump is this (major/minor/patch): ",
           "Changeset file created at ./#{changeset_path}",
           "Do you want to open this file to add more information? (y/N):"
         ), output
@@ -48,8 +47,8 @@ RSpec.describe Mono::Cli::Changeset do
         prepare_project :elixir_single
 
         add_cli_input "My Awes/o\\me pa.t`ch"
-        add_cli_input "1" # Type: "add"
-        add_cli_input "minor"
+        add_cli_input "1" # Type: Added
+        add_cli_input "2" # Bump: Minor
         add_cli_input "n"
         output =
           capture_stdout do
@@ -62,7 +61,6 @@ RSpec.describe Mono::Cli::Changeset do
         changeset_path = ".changesets/my-awes-o-me-pa-t-ch.md"
         expect(output).to include(
           "Summarize the change (for changeset filename):",
-          "What type of semver bump is this (major/minor/patch): ",
           "Changeset file created at ./#{changeset_path}",
           "Do you want to open this file to add more information? (y/N):"
         ), output
@@ -89,9 +87,9 @@ RSpec.describe Mono::Cli::Changeset do
 
         add_cli_input "My Awes/o\\me patch"
         add_cli_input "" # User presses enter without input
-        add_cli_input "unknown" # Unsupported type
-        add_cli_input "2" # Type: "change"
-        add_cli_input "patch" # Supported bump type
+        add_cli_input "unknown" # Type: Unsupported
+        add_cli_input "2" # Type: Change
+        add_cli_input "3" # Bump: Patch
         add_cli_input "n"
         output =
           capture_stdout do
@@ -100,7 +98,7 @@ RSpec.describe Mono::Cli::Changeset do
 
         changeset_path = ".changesets/my-awes-o-me-patch.md"
         expect(output).to include("Unknown type selected. Please select a type.")
-        expect(output.scan(/Select type /).length).to eql(3)
+        expect(output.scan(/Select change type /).length).to eql(3)
         in_project do
           expect(current_package_changeset_files.length).to eql(1)
           contents = File.read(changeset_path)
@@ -123,10 +121,10 @@ RSpec.describe Mono::Cli::Changeset do
         prepare_project :elixir_single
 
         add_cli_input "My Awes/o\\me patch"
-        add_cli_input "1" # Type: "add"
+        add_cli_input "1" # Type: Added
         add_cli_input "" # User presses enter without input
-        add_cli_input "unknown" # Unsupported bump type
-        add_cli_input "patch" # Supported bump type
+        add_cli_input "unknown" # Type: Unsupported
+        add_cli_input "3" # Bump: Patch
         add_cli_input "n"
         output =
           capture_stdout do
@@ -135,9 +133,9 @@ RSpec.describe Mono::Cli::Changeset do
 
         changeset_path = ".changesets/my-awes-o-me-patch.md"
         expect(output).to include(
-          "Unknown bump type `unknown`. Please specify supported bump type."
+          "Unknown bump type ``. Please select a supported bump type."
         )
-        expect(output.scan(/What type of semver bump is this/).length).to eql(3)
+        expect(output.scan(/Select bump 1-3/).length).to eql(3)
         in_project do
           expect(current_package_changeset_files.length).to eql(1)
           contents = File.read(changeset_path)
@@ -160,8 +158,8 @@ RSpec.describe Mono::Cli::Changeset do
         prepare_project :elixir_single
 
         add_cli_input "My Awes/o\\me patch"
-        add_cli_input "1" # Type: "add"
-        add_cli_input "patch"
+        add_cli_input "1" # Type: Added
+        add_cli_input "3" # Bump: Patch
         add_cli_input "y"
         output =
           capture_stdout do
@@ -184,8 +182,8 @@ RSpec.describe Mono::Cli::Changeset do
         prepare_project :elixir_single
 
         add_cli_input "My \"Awes/o\\mé', patch"
-        add_cli_input "1" # Type: "add"
-        add_cli_input "patch"
+        add_cli_input "1" # Type: Added
+        add_cli_input "3" # Bump: Patch
         add_cli_input "y"
         output =
           capture_stdout do
@@ -214,8 +212,8 @@ RSpec.describe Mono::Cli::Changeset do
       add_cli_input "3" # Invalid index, only 2 packages
       add_cli_input "1" # First package
       add_cli_input "My Awes/o\\me patch"
-      add_cli_input "1" # Type: "add"
-      add_cli_input "major"
+      add_cli_input "1" # Type: Added
+      add_cli_input "1" # Change: Major
       add_cli_input "n"
       output =
         capture_stdout do
@@ -227,7 +225,7 @@ RSpec.describe Mono::Cli::Changeset do
         "1: package_one (packages/package_one)",
         "2: package_two (packages/package_two)",
         "Summarize the change (for changeset filename):",
-        "What type of semver bump is this (major/minor/patch): ",
+        "What type of semver bump is this?",
         "Changeset file created at #{changeset_path}",
         "Do you want to open this file to add more information? (y/N):"
       ), output


### PR DESCRIPTION
The semver change bump type asked for a string value, while the change type was a prompt using number selection. To have us type less, use the number prompt for the semver bump selection as well.