### PR TITLE
Fix symbols in changeset filenames causing issues

### DIFF
--- a/.changesets/fix-symbols-in-changeset-filenames.md
+++ b/.changesets/fix-symbols-in-changeset-filenames.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix symbols not being replaced by dashes in changeset filenames. This could cause issues when trying to open it with an editor.

--- a/lib/mono/cli/changeset/add.rb
+++ b/lib/mono/cli/changeset/add.rb
@@ -19,7 +19,7 @@ module Mono
           FileUtils.touch(File.join(dir, ".gitkeep"))
           change_description =
             required_input("Summarize the change (for changeset filename): ")
-          filename = change_description.downcase.tr(":;.,'\"` /\\", "-")
+          filename = change_description.downcase.gsub(/\W/, "-")
           filepath = File.join(dir, "#{filename}.md")
           type = prompt_for_type
           bump = prompt_for_bump

--- a/spec/lib/mono/cli/changeset/add_spec.rb
+++ b/spec/lib/mono/cli/changeset/add_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Mono::Cli::Changeset do
       it "creates the .changeset directory and a changeset file" do
         prepare_project :elixir_single
 
-        add_cli_input "My:; Awes/o\\me pa.tch"
+        add_cli_input "My:; Awes/o\\me (pa).tch"
         add_cli_input "1" # Type: Added
         add_cli_input "3" # Bump: Patch
         add_cli_input "n"
@@ -19,7 +19,7 @@ RSpec.describe Mono::Cli::Changeset do
             in_project { run_changeset_add }
           end
 
-        changeset_path = ".changesets/my---awes-o-me-pa-tch.md"
+        changeset_path = ".changesets/my---awes-o-me--pa--tch.md"
         expect(output).to include(
           "Summarize the change (for changeset filename):",
           "Changeset file created at ./#{changeset_path}",
@@ -34,7 +34,7 @@ RSpec.describe Mono::Cli::Changeset do
             type: "add"
             ---
 
-            My:; Awes/o\\me pa.tch
+            My:; Awes/o\\me (pa).tch
           CHANGESET
         end
         expect(performed_commands).to eql([])
@@ -190,7 +190,7 @@ RSpec.describe Mono::Cli::Changeset do
             in_project { run_changeset_add }
           end
 
-        changeset_path = ".changesets/my--awes-o-mé---patch.md"
+        changeset_path = ".changesets/my--awes-o-m----patch.md"
         expect(output).to include(
           "Opening ./#{changeset_path} with editor..."
         )


### PR DESCRIPTION
The `tr` matchers were not capturing all the problematic symbols. Instead, match all non-word characters with a regular expression and replace them with a dash.