### PR TITLE
Add integrations prompt for agent project

### DIFF
--- a/.changesets/prompt-for-integrations.md
+++ b/.changesets/prompt-for-integrations.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: add
+---
+
+Prompt for integrations in the projects that include the `integrations` configuration. This will be used for internal projects.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ test:
             - Ruby only.
             - Specify which path the `.gem` files to publish can be found if
               not in the root of the project.
+- `integrations`
+    - List of integration options that are accepted.
+    - Example: `["ruby", "elixir", "nodejs"]`
 
 ### Customize commands
 

--- a/lib/mono/cli/changeset/add.rb
+++ b/lib/mono/cli/changeset/add.rb
@@ -23,11 +23,14 @@ module Mono
           filepath = File.join(dir, "#{filename}.md")
           type = prompt_for_type
           bump = prompt_for_bump
+          metadata = {
+            "bump" => bump,
+            "type" => type
+          }
 
+          metadata_yml = YAML.dump(metadata)
           File.write(filepath, <<~CONTENTS)
-            ---
-            bump: "#{bump}"
-            type: "#{type}"
+            #{metadata_yml.strip}
             ---
 
             #{change_description}

--- a/spec/lib/mono/cli/changeset/add_spec.rb
+++ b/spec/lib/mono/cli/changeset/add_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Mono::Cli::Changeset do
           contents = File.read(changeset_path)
           expect(contents).to eql(<<~CHANGESET)
             ---
-            bump: "patch"
-            type: "add"
+            bump: patch
+            type: add
             ---
 
             My:; Awes/o\\me (pa).tch
@@ -69,8 +69,8 @@ RSpec.describe Mono::Cli::Changeset do
           contents = File.read(changeset_path)
           expect(contents).to eql(<<~CHANGESET)
             ---
-            bump: "minor"
-            type: "add"
+            bump: minor
+            type: add
             ---
 
             My Awes/o\\me pa.t`ch
@@ -104,8 +104,8 @@ RSpec.describe Mono::Cli::Changeset do
           contents = File.read(changeset_path)
           expect(contents).to eql(<<~CHANGESET)
             ---
-            bump: "patch"
-            type: "change"
+            bump: patch
+            type: change
             ---
 
             My Awes/o\\me patch
@@ -141,8 +141,8 @@ RSpec.describe Mono::Cli::Changeset do
           contents = File.read(changeset_path)
           expect(contents).to eql(<<~CHANGESET)
             ---
-            bump: "patch"
-            type: "add"
+            bump: patch
+            type: add
             ---
 
             My Awes/o\\me patch
@@ -237,8 +237,8 @@ RSpec.describe Mono::Cli::Changeset do
         contents = File.read(changeset_path)
         expect(contents).to eql(<<~CHANGESET)
           ---
-          bump: "major"
-          type: "add"
+          bump: major
+          type: add
           ---
 
           My Awes/o\\me patch

--- a/spec/lib/mono/cli/changeset/add_spec.rb
+++ b/spec/lib/mono/cli/changeset/add_spec.rb
@@ -200,6 +200,240 @@ RSpec.describe Mono::Cli::Changeset do
         expect(exit_status).to eql(0), output
       end
     end
+
+    context "with integrations config" do
+      it "stores a single integration" do
+        prepare_ruby_project("integrations" => ["ruby", "elixir", "python"]) do
+          create_ruby_package_files :name => "mygem", :version => "1.2.3"
+        end
+
+        add_cli_input "My change"
+        add_cli_input "1" # Type: Added
+        add_cli_input "3" # Bump: Patch
+        add_cli_input "ruby"
+        add_cli_input "n"
+        output = capture_stdout { in_project { run_changeset_add } }
+
+        changeset_path = ".changesets/my-change.md"
+        expect(output).to include(
+          "For which integrations is this change? (all, none, ruby, elixir, python): "
+        )
+        in_project do
+          contents = File.read(changeset_path)
+          expect(contents).to eql(<<~CHANGESET)
+            ---
+            bump: patch
+            type: add
+            integrations: ruby
+            ---
+
+            My change
+          CHANGESET
+        end
+        expect(performed_commands).to be_empty
+        expect(exit_status).to eql(0), output
+      end
+
+      it "stores multiple integrations" do
+        prepare_ruby_project("integrations" => ["ruby", "elixir", "python"]) do
+          create_ruby_package_files :name => "mygem", :version => "1.2.3"
+        end
+
+        add_cli_input "My change"
+        add_cli_input "1" # Type: Added
+        add_cli_input "3" # Bump: Patch
+        add_cli_input "ruby, elixir"
+        add_cli_input "n"
+        output = capture_stdout { in_project { run_changeset_add } }
+
+        changeset_path = ".changesets/my-change.md"
+        expect(output).to include(
+          "For which integrations is this change? (all, none, ruby, elixir, python): "
+        )
+        in_project do
+          contents = File.read(changeset_path)
+          expect(contents).to eql(<<~CHANGESET)
+            ---
+            bump: patch
+            type: add
+            integrations:
+            - ruby
+            - elixir
+            ---
+
+            My change
+          CHANGESET
+        end
+        expect(performed_commands).to be_empty
+        expect(exit_status).to eql(0), output
+      end
+
+      it "accept 'all' as integrations" do
+        prepare_ruby_project("integrations" => ["ruby", "elixir", "python"]) do
+          create_ruby_package_files :name => "mygem", :version => "1.2.3"
+        end
+
+        add_cli_input "My change"
+        add_cli_input "1" # Type: Added
+        add_cli_input "3" # Bump: Patch
+        add_cli_input "all"
+        add_cli_input "n"
+        output = capture_stdout { in_project { run_changeset_add } }
+
+        changeset_path = ".changesets/my-change.md"
+        expect(output).to include(
+          "For which integrations is this change? (all, none, ruby, elixir, python): "
+        )
+        in_project do
+          contents = File.read(changeset_path)
+          expect(contents).to eql(<<~CHANGESET)
+            ---
+            bump: patch
+            type: add
+            integrations: all
+            ---
+
+            My change
+          CHANGESET
+        end
+        expect(performed_commands).to be_empty
+        expect(exit_status).to eql(0), output
+      end
+
+      it "accept only 'all' as integrations" do
+        prepare_ruby_project("integrations" => ["ruby", "elixir", "python"]) do
+          create_ruby_package_files :name => "mygem", :version => "1.2.3"
+        end
+
+        add_cli_input "My change"
+        add_cli_input "1" # Type: Added
+        add_cli_input "3" # Bump: Patch
+        add_cli_input "ruby, all"
+        add_cli_input "n"
+        output = capture_stdout { in_project { run_changeset_add } }
+
+        changeset_path = ".changesets/my-change.md"
+        expect(output).to include(
+          "For which integrations is this change? (all, none, ruby, elixir, python): "
+        )
+        in_project do
+          contents = File.read(changeset_path)
+          expect(contents).to eql(<<~CHANGESET)
+            ---
+            bump: patch
+            type: add
+            integrations: all
+            ---
+
+            My change
+          CHANGESET
+        end
+        expect(performed_commands).to be_empty
+        expect(exit_status).to eql(0), output
+      end
+
+      it "accept 'none' as integrations" do
+        prepare_ruby_project("integrations" => ["ruby", "elixir", "python"]) do
+          create_ruby_package_files :name => "mygem", :version => "1.2.3"
+        end
+
+        add_cli_input "My change"
+        add_cli_input "1" # Type: Added
+        add_cli_input "3" # Bump: Patch
+        add_cli_input "none"
+        add_cli_input "n"
+        output = capture_stdout { in_project { run_changeset_add } }
+
+        changeset_path = ".changesets/my-change.md"
+        expect(output).to include(
+          "For which integrations is this change? (all, none, ruby, elixir, python): "
+        )
+        in_project do
+          contents = File.read(changeset_path)
+          expect(contents).to eql(<<~CHANGESET)
+            ---
+            bump: patch
+            type: add
+            integrations: none
+            ---
+
+            My change
+          CHANGESET
+        end
+        expect(performed_commands).to be_empty
+        expect(exit_status).to eql(0), output
+      end
+
+      it "accept only 'none' as integrations" do
+        prepare_ruby_project("integrations" => ["ruby", "elixir", "python"]) do
+          create_ruby_package_files :name => "mygem", :version => "1.2.3"
+        end
+
+        add_cli_input "My change"
+        add_cli_input "1" # Type: Added
+        add_cli_input "3" # Bump: Patch
+        add_cli_input "elixir, none"
+        add_cli_input "n"
+        output = capture_stdout { in_project { run_changeset_add } }
+
+        changeset_path = ".changesets/my-change.md"
+        expect(output).to include(
+          "For which integrations is this change? (all, none, ruby, elixir, python): "
+        )
+        in_project do
+          contents = File.read(changeset_path)
+          expect(contents).to eql(<<~CHANGESET)
+            ---
+            bump: patch
+            type: add
+            integrations: none
+            ---
+
+            My change
+          CHANGESET
+        end
+        expect(performed_commands).to be_empty
+        expect(exit_status).to eql(0), output
+      end
+
+      it "does not accept unknown integrations" do
+        prepare_ruby_project("integrations" => ["ruby", "elixir", "python"]) do
+          create_ruby_package_files :name => "mygem", :version => "1.2.3"
+        end
+
+        add_cli_input "My change"
+        add_cli_input "1" # Type: Added
+        add_cli_input "3" # Bump: Patch
+        add_cli_input "" # Empty value
+        add_cli_input ",,," # Empty list gets ignored
+        add_cli_input "random 1"
+        add_cli_input "random 1, , random 2" # Multiple values with empty value
+        add_cli_input "python"
+        add_cli_input "n"
+        output = capture_stdout { in_project { run_changeset_add } }
+
+        changeset_path = ".changesets/my-change.md"
+        expect(output).to include(
+          "For which integrations is this change? (all, none, ruby, elixir, python): ",
+          "Unknown integration entered: \"random 1\". Please try again.",
+          "Unknown integration entered: \"random 1\", \"random 2\". Please try again."
+        )
+        in_project do
+          contents = File.read(changeset_path)
+          expect(contents).to eql(<<~CHANGESET)
+            ---
+            bump: patch
+            type: add
+            integrations: python
+            ---
+
+            My change
+          CHANGESET
+        end
+        expect(performed_commands).to be_empty
+        expect(exit_status).to eql(0), output
+      end
+    end
   end
 
   context "with mono repo" do


### PR DESCRIPTION
## Generate changeset YAML metadata with YAML

Instead of building the YAML metadata using our own Ruby template, just use the Ruby YAML library.

I kept the order of the YAML keys the same so nothing changes, only the quotes around the values written.

## Add integrations prompt for agent project

Add a prompt that automates the integrations metadata being set for changesets.

Accepted values include the configured options, but also "all" and "none", which are understood by the agent's release process.

Closes #73
