### PR TITLE
Add changelog to Git tags

### DIFF
--- a/.changesets/add-changelog-to-release-tag.md
+++ b/.changesets/add-changelog-to-release-tag.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: add
+---
+
+Add the changeset entries to release tag. The changelog contents are visible via `git show {release tag}`.

--- a/spec/lib/mono/cli/publish/custom_spec.rb
+++ b/spec/lib/mono/cli/publish/custom_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Mono::Cli::Publish do
 
     project_dir = current_project_path
     next_version = "1.2.3a2"
+    tag = "v#{next_version}"
 
     expect(output).to has_publish_and_update_summary(
       current_project => { :old => "v1.2.3a1", :new => "v1.2.3a2", :bump => :patch }
@@ -46,18 +47,18 @@ RSpec.describe Mono::Cli::Publish do
 
     expect(performed_commands).to eql([
       [project_dir, "cat version.py"],
-      [project_dir, "git tag --list v#{next_version}"],
+      [project_dir, "git tag --list #{tag}"],
       [project_dir, "ruby write_version_file.rb #{next_version}"],
       [project_dir, "echo build"],
       [project_dir, "git add -A"],
       [
         project_dir,
-        "git commit -m 'Publish package v#{next_version}' " \
+        "git commit -m 'Publish package #{tag}' " \
           "-m 'Update version number and CHANGELOG.md.'"
       ],
-      [project_dir, "git tag v#{next_version}"],
+      [project_dir, version_tag_command(tag)],
       [project_dir, "echo publish"],
-      [project_dir, "git push origin main v#{next_version}"]
+      [project_dir, "git push origin main #{tag}"]
     ])
     expect(exit_status).to eql(0), output
   end

--- a/spec/lib/mono/cli/publish/elixir_spec.rb
+++ b/spec/lib/mono/cli/publish/elixir_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Mono::Cli::Publish do
 
       project_dir = current_project_path
       next_version = "1.2.4"
+      tag = "v#{next_version}"
 
       expect(output).to has_publish_and_update_summary(
         current_project => { :old => "v1.2.3", :new => "v1.2.4", :bump => :patch }
@@ -39,7 +40,7 @@ RSpec.describe Mono::Cli::Publish do
 
       expect(performed_commands).to eql([
         [project_dir, "mix deps.get"],
-        [project_dir, "git tag --list v#{next_version}"],
+        [project_dir, "git tag --list #{tag}"],
         [project_dir, "mix compile"],
         [project_dir, "git add -A"],
         [
@@ -47,7 +48,7 @@ RSpec.describe Mono::Cli::Publish do
           "git commit -m 'Publish package v#{next_version}' " \
             "-m 'Update version number and CHANGELOG.md.'"
         ],
-        [project_dir, "git tag v#{next_version}"],
+        [project_dir, version_tag_command(tag)],
         [project_dir, "mix hex.publish package --yes"],
         [project_dir, "git push origin main v#{next_version}"]
       ])
@@ -66,6 +67,7 @@ RSpec.describe Mono::Cli::Publish do
 
       project_dir = current_project_path
       next_version = "1.2.4"
+      tag = "v#{next_version}"
 
       expect(output).to has_publish_and_update_summary(
         current_project => { :old => "v1.2.3", :new => "v1.2.4", :bump => :patch }
@@ -91,17 +93,17 @@ RSpec.describe Mono::Cli::Publish do
 
       expect(performed_commands).to eql([
         [project_dir, "mix deps.get"],
-        [project_dir, "git tag --list v#{next_version}"],
+        [project_dir, "git tag --list #{tag}"],
         [project_dir, "mix compile"],
         [project_dir, "git add -A"],
         [
           project_dir,
-          "git commit -m 'Publish package v#{next_version}' " \
+          "git commit -m 'Publish package #{tag}' " \
             "-m 'Update version number and CHANGELOG.md.'"
         ],
-        [project_dir, "git tag v#{next_version}"],
+        [project_dir, version_tag_command(tag)],
         [project_dir, "mix hex.publish package --yes"],
-        [project_dir, "git push origin main v#{next_version}"]
+        [project_dir, "git push origin main #{tag}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -161,7 +163,7 @@ RSpec.describe Mono::Cli::Publish do
           "git commit -m 'Publish package #{tag}' " \
             "-m 'Update version number and CHANGELOG.md.'"
         ],
-        [project_dir, "git tag #{tag}"],
+        [project_dir, version_tag_command(tag, tmp_changelog_file_for("package_a"))],
         [package_dir_a, "mix hex.publish package --yes"],
         [project_dir, "git push origin main #{tag}"]
       ])
@@ -236,8 +238,8 @@ RSpec.describe Mono::Cli::Publish do
           "git commit -m 'Publish packages' " \
             "-m 'Update version number and CHANGELOG.md.\n\n- #{tag_a}\n- #{tag_b}'"
         ],
-        [project_dir, "git tag #{tag_a}"],
-        [project_dir, "git tag #{tag_b}"],
+        [project_dir, version_tag_command(tag_a, tmp_changelog_file_for("jason"))],
+        [project_dir, version_tag_command(tag_b, tmp_changelog_file_for("package_b"))],
         [package_dir_a, "mix hex.publish package --yes"],
         [package_dir_b, "mix hex.publish package --yes"],
         [project_dir, "git push origin main #{tag_a} #{tag_b}"]

--- a/spec/lib/mono/cli/publish/nodejs_spec.rb
+++ b/spec/lib/mono/cli/publish/nodejs_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Mono::Cli::Publish do
             project_dir,
             "git commit -m 'Publish package #{tag}' -m 'Update version number and CHANGELOG.md.'"
           ],
-          [project_dir, "git tag #{tag}"],
+          [project_dir, version_tag_command(tag, tmp_changelog_file_for("my_package"))],
           [project_dir, "npm publish"],
           [project_dir, "git push origin main #{tag}"]
         ])
@@ -85,7 +85,7 @@ RSpec.describe Mono::Cli::Publish do
             project_dir,
             "git commit -m 'Publish package #{tag}' -m 'Update version number and CHANGELOG.md.'"
           ],
-          [project_dir, "git tag #{tag}"],
+          [project_dir, version_tag_command(tag, tmp_changelog_file_for("my_package"))],
           [project_dir, "npm publish --tag alpha"],
           [project_dir, "git push origin main #{tag}"]
         ])
@@ -122,7 +122,7 @@ RSpec.describe Mono::Cli::Publish do
             project_dir,
             "git commit -m 'Publish package #{tag}' -m 'Update version number and CHANGELOG.md.'"
           ],
-          [project_dir, "git tag #{tag}"],
+          [project_dir, version_tag_command(tag, tmp_changelog_file_for("my_package"))],
           [project_dir, "npm publish --tag beta"],
           [project_dir, "git push origin main #{tag}"]
         ])
@@ -160,7 +160,7 @@ RSpec.describe Mono::Cli::Publish do
             project_dir,
             "git commit -m 'Publish package #{tag}' -m 'Update version number and CHANGELOG.md.'"
           ],
-          [project_dir, "git tag #{tag}"],
+          [project_dir, version_tag_command(tag, tmp_changelog_file_for("my_package"))],
           [project_dir, "npm publish --tag #{package_tag}"],
           [project_dir, "git push origin main #{tag}"]
         ])
@@ -197,7 +197,7 @@ RSpec.describe Mono::Cli::Publish do
             project_dir,
             "git commit -m 'Publish package #{tag}' -m 'Update version number and CHANGELOG.md.'"
           ],
-          [project_dir, "git tag #{tag}"],
+          [project_dir, version_tag_command(tag, tmp_changelog_file_for("my_package"))],
           [project_dir, "npm publish --tag rc"],
           [project_dir, "git push origin main #{tag}"]
         ])
@@ -262,7 +262,7 @@ RSpec.describe Mono::Cli::Publish do
             project_dir,
             "git commit -m 'Publish package #{tag}' -m 'Update version number and CHANGELOG.md.'"
           ],
-          [project_dir, "git tag #{tag}"],
+          [project_dir, version_tag_command(tag, tmp_changelog_file_for("package_one"))],
           [package_one_dir, "npm publish"],
           [project_dir, "git push origin main #{tag}"]
         ])
@@ -347,8 +347,14 @@ RSpec.describe Mono::Cli::Publish do
             "git commit -m 'Publish packages' -m 'Update version number and CHANGELOG.md.\n\n" \
               "- #{package_one_tag}\n- #{package_two_tag}'"
           ],
-          [project_dir, "git tag #{package_one_tag}"],
-          [project_dir, "git tag #{package_two_tag}"],
+          [
+            project_dir,
+            version_tag_command(package_one_tag, tmp_changelog_file_for("package_one"))
+          ],
+          [
+            project_dir,
+            version_tag_command(package_two_tag, tmp_changelog_file_for("package_two"))
+          ],
           [package_one_dir, "npm publish"],
           [package_two_dir, "npm publish"],
           [project_dir, "git push origin main #{package_one_tag} #{package_two_tag}"]
@@ -488,9 +494,9 @@ RSpec.describe Mono::Cli::Publish do
             "git commit -m 'Publish packages' -m 'Update version number and CHANGELOG.md.\n\n" \
               "- #{package_tag_a}\n- #{package_tag_b}\n- #{package_tag_c}'"
           ],
-          [project_dir, "git tag #{package_tag_a}"],
-          [project_dir, "git tag #{package_tag_b}"],
-          [project_dir, "git tag #{package_tag_c}"],
+          [project_dir, version_tag_command(package_tag_a, tmp_changelog_file_for("package_a"))],
+          [project_dir, version_tag_command(package_tag_b, tmp_changelog_file_for("package_b"))],
+          [project_dir, version_tag_command(package_tag_c, tmp_changelog_file_for("package_c"))],
           [package_dir_a, "npm publish"],
           [package_dir_b, "npm publish"],
           [package_dir_c, "npm publish"],
@@ -577,8 +583,8 @@ RSpec.describe Mono::Cli::Publish do
             "git commit -m 'Publish packages' -m 'Update version number and CHANGELOG.md.\n\n" \
               "- #{package_tag_a}\n- #{package_tag_b}'"
           ],
-          [project_dir, "git tag #{package_tag_a}"],
-          [project_dir, "git tag #{package_tag_b}"],
+          [project_dir, version_tag_command(package_tag_a, tmp_changelog_file_for("package_a"))],
+          [project_dir, version_tag_command(package_tag_b, tmp_changelog_file_for("package_b"))],
           [package_dir_a, "npm publish --tag alpha"],
           [package_dir_b, "npm publish --tag alpha"],
           [project_dir, "git push origin main #{package_tag_a} #{package_tag_b}"]
@@ -666,8 +672,8 @@ RSpec.describe Mono::Cli::Publish do
             "git commit -m 'Publish packages' -m 'Update version number and CHANGELOG.md.\n\n" \
               "- #{package_tag_a}\n- #{package_tag_b}'"
           ],
-          [project_dir, "git tag #{package_tag_a}"],
-          [project_dir, "git tag #{package_tag_b}"],
+          [project_dir, version_tag_command(package_tag_a, tmp_changelog_file_for("package_a"))],
+          [project_dir, version_tag_command(package_tag_b, tmp_changelog_file_for("package_b"))],
           [package_dir_a, "npm publish"],
           [package_dir_b, "npm publish"],
           [project_dir, "git push origin main #{package_tag_a} #{package_tag_b}"]
@@ -720,7 +726,7 @@ RSpec.describe Mono::Cli::Publish do
             project_dir,
             "git commit -m 'Publish package #{tag}' -m 'Update version number and CHANGELOG.md.'"
           ],
-          [project_dir, "git tag #{tag}"],
+          [project_dir, version_tag_command(tag, tmp_changelog_file_for("my_package"))],
           [project_dir, "yarn publish --new-version #{next_version}"],
           [project_dir, "git push origin main #{tag}"]
         ])

--- a/spec/lib/mono/cli/publish/ruby_spec.rb
+++ b/spec/lib/mono/cli/publish/ruby_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Mono::Cli::Publish do
 
       project_dir = current_project_path
       next_version = "1.2.4"
+      tag = "v#{next_version}"
 
       expect(output).to has_publish_and_update_summary(
         current_project => { :old => "v1.2.3", :new => "v1.2.4", :bump => :patch }
@@ -38,17 +39,17 @@ RSpec.describe Mono::Cli::Publish do
       end
 
       expect(performed_commands).to eql([
-        [project_dir, "git tag --list v#{next_version}"],
+        [project_dir, "git tag --list #{tag}"],
         [project_dir, "gem build"],
         [project_dir, "git add -A"],
         [
           project_dir,
-          "git commit -m 'Publish package v#{next_version}' " \
+          "git commit -m 'Publish package #{tag}' " \
             "-m 'Update version number and CHANGELOG.md.'"
         ],
-        [project_dir, "git tag v#{next_version}"],
+        [project_dir, version_tag_command(tag)],
         [project_dir, "gem push mygem-#{next_version}.gem"],
-        [project_dir, "git push origin main v#{next_version}"]
+        [project_dir, "git push origin main #{tag}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -66,6 +67,7 @@ RSpec.describe Mono::Cli::Publish do
 
         project_dir = current_project_path
         next_version = "1.2.4"
+        tag = "v#{next_version}"
 
         expect(output).to has_publish_and_update_summary(
           current_project => { :old => "v1.2.3", :new => "v1.2.4", :bump => :patch }
@@ -88,18 +90,18 @@ RSpec.describe Mono::Cli::Publish do
         end
 
         expect(performed_commands).to eql([
-          [project_dir, "git tag --list v#{next_version}"],
+          [project_dir, "git tag --list #{tag}"],
           [project_dir, "gem build"],
           [project_dir, "git add -A"],
           [
             project_dir,
-            "git commit -m 'Publish package v#{next_version}' " \
+            "git commit -m 'Publish package #{tag}' " \
               "-m 'Update version number and CHANGELOG.md.'"
           ],
-          [project_dir, "git tag v#{next_version}"],
+          [project_dir, version_tag_command(tag)],
           [project_dir, "gem push mygem-#{next_version}.gem"],
           [project_dir, "gem push mygem-#{next_version}-java.gem"],
-          [project_dir, "git push origin main v#{next_version}"]
+          [project_dir, "git push origin main #{tag}"]
         ])
         expect(exit_status).to eql(0), output
       end
@@ -118,6 +120,7 @@ RSpec.describe Mono::Cli::Publish do
 
       project_dir = current_project_path
       next_version = "1.2.4"
+      tag = "v#{next_version}"
 
       expect(output).to has_publish_and_update_summary(
         current_project => { :old => "v1.2.3", :new => "v1.2.4", :bump => :patch }
@@ -140,17 +143,17 @@ RSpec.describe Mono::Cli::Publish do
       end
 
       expect(performed_commands).to eql([
-        [project_dir, "git tag --list v#{next_version}"],
+        [project_dir, "git tag --list #{tag}"],
         [project_dir, "echo build"],
         [project_dir, "git add -A"],
         [
           project_dir,
-          "git commit -m 'Publish package v#{next_version}' " \
+          "git commit -m 'Publish package #{tag}' " \
             "-m 'Update version number and CHANGELOG.md.'"
         ],
-        [project_dir, "git tag v#{next_version}"],
+        [project_dir, version_tag_command(tag)],
         [project_dir, "echo push"],
-        [project_dir, "git push origin main v#{next_version}"]
+        [project_dir, "git push origin main #{tag}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -207,7 +210,7 @@ RSpec.describe Mono::Cli::Publish do
           "git commit -m 'Publish package #{tag_a}' " \
             "-m 'Update version number and CHANGELOG.md.'"
         ],
-        [project_dir, "git tag #{tag_a}"],
+        [project_dir, version_tag_command(tag_a, tmp_changelog_file_for("package_a"))],
         [project_dir, "gem push packages/package_a/package_a-#{next_version_a}.gem"],
         [project_dir, "git push origin main #{tag_a}"]
       ])
@@ -281,8 +284,8 @@ RSpec.describe Mono::Cli::Publish do
           "git commit -m 'Publish packages' " \
             "-m 'Update version number and CHANGELOG.md.\n\n- #{tag_a}\n- #{tag_b}'"
         ],
-        [project_dir, "git tag #{tag_a}"],
-        [project_dir, "git tag #{tag_b}"],
+        [project_dir, version_tag_command(tag_a, tmp_changelog_file_for("package_a"))],
+        [project_dir, version_tag_command(tag_b, tmp_changelog_file_for("package_b"))],
         [project_dir, "gem push packages/package_a/package_a-#{next_version_a}.gem"],
         [project_dir, "gem push packages/package_b/package_b-#{next_version_b}.gem"],
         [project_dir, "git push origin main #{tag_a} #{tag_b}"]
@@ -380,9 +383,9 @@ RSpec.describe Mono::Cli::Publish do
           "git commit -m 'Publish packages' " \
             "-m 'Update version number and CHANGELOG.md.\n\n- #{tag_a}\n- #{tag_b}\n- #{tag_c}'"
         ],
-        [project_dir, "git tag #{tag_a}"],
-        [project_dir, "git tag #{tag_b}"],
-        [project_dir, "git tag #{tag_c}"],
+        [project_dir, version_tag_command(tag_a, tmp_changelog_file_for("package_a"))],
+        [project_dir, version_tag_command(tag_b, tmp_changelog_file_for("package_b"))],
+        [project_dir, version_tag_command(tag_c, tmp_changelog_file_for("package_c"))],
         [project_dir, "gem push packages/package_a/package_a-#{next_version_a}.gem"],
         [project_dir, "gem push packages/package_b/package_b-#{next_version_b}.gem"],
         [project_dir, "gem push packages/package_c/package_c-#{next_version_c}.gem"],

--- a/spec/support/helpers/git_helper.rb
+++ b/spec/support/helpers/git_helper.rb
@@ -27,4 +27,17 @@ module GitHelper
     run_command "git add -A"
     run_command %(git commit -m "#{message}")
   end
+
+  def tag_changelog_contents(tag)
+    contents = `git show --format=oneline --no-color --no-patch #{tag}`
+    contents.lines[2..-2].join.strip
+  end
+
+  def tmp_changelog_file_for(project)
+    "tmp/#{project}_changesets.txt"
+  end
+
+  def version_tag_command(tag, file = tmp_changelog_file_for(current_project))
+    "git tag #{tag} --annotate --cleanup=verbatim --file #{file}"
+  end
 end


### PR DESCRIPTION
Store the changelog (in a simplified) format on the Git tag. This can be viewed by running `git show {tag}`.

This allows us to automate some things that require the changelog. It will be easier to fetch the changelog from the tag, instead of parsing the `CHANGELOG.md` file.

[skip review]