### PR TITLE
Fix tag annotation for package names with symbols

### DIFF
--- a/.changesets/fix-tag-annotation-for-packages-with-symbols-in-their-name.md
+++ b/.changesets/fix-tag-annotation-for-packages-with-symbols-in-their-name.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix tag annotation for packages with symbols in their name.

--- a/lib/mono.rb
+++ b/lib/mono.rb
@@ -39,6 +39,7 @@ module Mono
   end
 end
 
+require "mono/utils"
 require "mono/shell"
 require "mono/version"
 require "mono/version_object"

--- a/lib/mono/cli/changeset/add.rb
+++ b/lib/mono/cli/changeset/add.rb
@@ -19,7 +19,7 @@ module Mono
           FileUtils.touch(File.join(dir, ".gitkeep"))
           change_description =
             required_input("Summarize the change (for changeset filename): ")
-          filename = change_description.downcase.gsub(/\W/, "-")
+          filename = Utils.normalize_filename(change_description)
           filepath = File.join(dir, "#{filename}.md")
           type = prompt_for_type
           bump = prompt_for_bump

--- a/lib/mono/cli/publish.rb
+++ b/lib/mono/cli/publish.rb
@@ -248,7 +248,11 @@ module Mono
           puts "## Tag package #{package.next_tag}"
 
           prepare_tmp_dir
-          tmp_file = File.join(TMP_DIR, "#{package.name}_changesets.txt")
+          normalized_package_name = Utils.normalize_filename(package.name.to_s)
+          tmp_file = File.join(
+            TMP_DIR,
+            "#{normalized_package_name}_changesets.txt"
+          )
           File.write(tmp_file, changesets[package.name].join)
 
           run_command "git tag #{package.next_tag} " \

--- a/lib/mono/utils.rb
+++ b/lib/mono/utils.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Mono
+  module Utils
+    def self.normalize_filename(filename)
+      filename.downcase.gsub(/\W/, "-")
+    end
+  end
+end


### PR DESCRIPTION
When tagging a package release for a package with a name like `@org/package`, it would error on the symbols on the name.

Fix it by normalizing the name. I've moved this to a helper as we used it in another place too.