### PR TITLE
Format changelog to move link to end of line

### DIFF
--- a/.changesets/update-changelog-format.md
+++ b/.changesets/update-changelog-format.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: change
+---
+
+Update changelog format to move related commit and version bump information to the end of the line. This matches the https://keepachangelog.com/en/1.1.0/ format better.

--- a/lib/mono/changeset_collection.rb
+++ b/lib/mono/changeset_collection.rb
@@ -82,19 +82,35 @@ module Mono
 
     private
 
+    CHANGELOG_INDENT = " " * 2
+
     def build_changelog_entry(changeset, format: :changelog)
-      message = ["- "]
+      changeset_message = indent_message(changeset.message)
+      message = ["- #{changeset_message.strip}"]
       if format == :changelog
+        message <<
+          if changeset_message.lines.count > 1
+            "\n\n#{CHANGELOG_INDENT}"
+          else
+            " "
+          end
+        message << "(#{changeset.bump}"
         commit = changeset.commit
         if commit
           url = "#{config.repo}/commit/#{commit[:long]}"
-          message << "[#{commit[:short]}](#{url}) "
+          message << " [#{commit[:short]}](#{url})"
         end
-        message << changeset.bump
-        message << " - "
+        message << ")"
       end
-      message << "#{changeset.message.lines.join("  ")}\n"
+      message << "\n"
       message.join
+    end
+
+    def indent_message(message)
+      message
+        .lines
+        .map { |line| "#{CHANGELOG_INDENT}#{line}".rstrip }
+        .join("\n")
     end
   end
 end

--- a/spec/lib/mono/changeset_collection_spec.rb
+++ b/spec/lib/mono/changeset_collection_spec.rb
@@ -233,32 +233,75 @@ RSpec.describe Mono::ChangesetCollection do
 
           ### Added
 
-          - [LINK] major - This is a major changeset bump.
-          - [LINK] minor - This is a minor changeset bump.
-          - [LINK] patch - This is a patch changeset bump.
+          - This is a major changeset bump. (major [LINK])
+          - This is a minor changeset bump. (minor [LINK])
+          - This is a patch changeset bump. (patch [LINK])
 
           ### Changed
 
-          - [LINK] major - This is a major changeset bump.
-          - [LINK] minor - This is a minor changeset bump.
-          - [LINK] patch - This is a patch changeset bump.
+          - This is a major changeset bump. (major [LINK])
+          - This is a minor changeset bump. (minor [LINK])
+          - This is a patch changeset bump. (patch [LINK])
 
           ### Deprecated
 
-          - [LINK] patch - This is a patch changeset bump.
+          - This is a patch changeset bump. (patch [LINK])
 
           ### Removed
 
-          - [LINK] major - This is a major changeset bump.
-          - [LINK] patch - This is a patch changeset bump.
+          - This is a major changeset bump. (major [LINK])
+          - This is a patch changeset bump. (patch [LINK])
 
           ### Fixed
 
-          - [LINK] patch - This is a patch changeset bump.
+          - This is a patch changeset bump. (patch [LINK])
 
           ### Security
 
-          - [LINK] patch - This is a patch changeset bump.
+          - This is a patch changeset bump. (patch [LINK])
+
+        CHANGELOG
+      end
+    end
+
+    it "adds the changeset metadata at the end of a multi line change" do
+      prepare_elixir_project do
+        create_package_mix :version => "1.2.3"
+        create_changelog
+        add_changeset :major,
+          :type => :add,
+          :message => <<~MESSAGE
+            Multi
+            Line
+
+            Change
+
+            ```ruby
+            Code example
+            ```
+          MESSAGE
+      end
+
+      in_project do
+        collection.write_changesets_to_changelog
+        changelog = normalize_changelog(read_changelog_file)
+        expect(changelog).to include(<<~CHANGELOG)
+          ## 2.0.0
+
+          _Published on #{date_label}._
+
+          ### Added
+
+          - Multi
+            Line
+
+            Change
+
+            ```ruby
+            Code example
+            ```
+
+            (major [LINK])
         CHANGELOG
       end
     end
@@ -282,12 +325,12 @@ RSpec.describe Mono::ChangesetCollection do
 
           ### Deprecated
 
-          - [LINK] patch - This is a patch changeset bump.
+          - This is a patch changeset bump. (patch [LINK])
 
           ### Removed
 
-          - [LINK] major - This is a major changeset bump.
-          - [LINK] patch - This is a patch changeset bump.
+          - This is a major changeset bump. (major [LINK])
+          - This is a patch changeset bump. (patch [LINK])
         CHANGELOG
       end
     end
@@ -295,7 +338,8 @@ RSpec.describe Mono::ChangesetCollection do
 
   def normalize_changelog(content)
     # Remove links so we don't have to try and match against every instance
-    content.gsub(/\[[a-z0-9]{7}\]\(.+\)/, "[LINK]")
+    content
+      .gsub(/\[[a-z0-9]{7}\]\([^)]+\)/, "[LINK]")
   end
 
   def date_label

--- a/spec/support/helpers/publish_helper.rb
+++ b/spec/support/helpers/publish_helper.rb
@@ -23,15 +23,15 @@ module PublishHelper
     url = "https://github.com/appsignal/#{current_project}"
     message ||= "This is a #{bump} changeset bump."
     expect(changelog)
-      .to match(%r{- \[[a-z0-9]{7}\]\(#{url}/commit/[a-z0-9]{40}\) #{bump} - #{message}})
+      .to match(%r{- #{message} \(#{bump} \[[a-z0-9]{7}\]\(#{url}/commit/[a-z0-9]{40}\)\)})
   end
 
   def expect_changelog_to_include_message(changelog, bump, message)
-    expect(changelog).to match(/- #{bump} - #{message}/)
+    expect(changelog).to match(/- #{message} \(#{bump}\)/)
   end
 
   def expect_changelog_to_include_package_bump(changelog, package, version)
-    message = "Update #{package} dependency to #{version}"
+    message = "Update #{package} dependency to #{version}."
     expect_changelog_to_include_message(changelog, "patch", message)
   end
 


### PR DESCRIPTION
Make generated changelogs more readable by moving he link and changeset bump to the end of the line. Focus on the change, rather than the technical details.

On multi line changes it will put the details at the end on a new line.

This matches the https://keepachangelog.com/en/1.1.0/ format better.