### PR TITLE
Mono auto update

### DIFF
--- a/.changesets/add-auto-update-functionality.md
+++ b/.changesets/add-auto-update-functionality.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: add
+---
+
+Add auto-update functionality. When using Mono, it will first check for updates, automatically updating itself to the latest version in the `origin` repository. This check will only be performed at most once every twenty-four hours.

--- a/bin/mono
+++ b/bin/mono
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+CHECK_FOR_UPDATES_AFTER = 60 * 60 * 24 # 1 day
+
 module MonoCheck
   def self.run(command)
     read, write = IO.pipe
@@ -10,6 +12,15 @@ module MonoCheck
     Process.wait pid
     write.close
     read.read
+  end
+
+  def self.run!(command)
+    output = run(command)
+    unless $?.success?
+      puts "ERROR: Command failed: #{command}"
+      exit 1
+    end
+    output
   end
 end
 
@@ -24,7 +35,7 @@ if $?.success?
     exit 1
   end
 
-  current_branch = MonoCheck.run("git rev-parse --abbrev-ref HEAD").chomp
+  current_branch = MonoCheck.run!("git rev-parse --abbrev-ref HEAD").chomp
   unless current_branch == "main"
     puts "ERROR: The mono repository is not on the `main` branch. " \
       "Please switch to the main branch to ensure you're using a released " \
@@ -32,6 +43,32 @@ if $?.success?
     puts "Please use the `mono-dev` executable if you want to use " \
       "uncommitted changes to _test_ mono itself."
     exit 1
+  end
+
+  repository_root = MonoCheck.run!("git rev-parse --show-toplevel").chomp
+  fetch_head = File.join(repository_root, ".git", "FETCH_HEAD")
+
+  last_modified = File.exist?(fetch_head) ? File.mtime(fetch_head) : Time.at(0)
+  if Time.now - last_modified > CHECK_FOR_UPDATES_AFTER
+    puts "Checking for updates..."
+    previous_version = MonoCheck.run!("git rev-parse --short HEAD").chomp
+    fetch_output = MonoCheck.run("git fetch origin main")
+    if $?.success?
+      MonoCheck.run!("git reset --hard origin/main")
+      latest_version = MonoCheck.run!("git rev-parse --short HEAD").chomp
+
+      if previous_version == latest_version
+        puts "You are running the latest version of Mono (#{latest_version})"
+      else
+        puts "Updated Mono to the latest version " \
+          "(#{previous_version} -> #{latest_version})"
+        exec File.join(__dir__, "mono"), *ARGV
+      end
+    else
+      puts "WARNING: Could not check for updates (#{fetch_output.chomp})"
+      puts "Continuing with current version."
+    end
+    puts
   end
 end
 

--- a/bin/mono
+++ b/bin/mono
@@ -24,34 +24,14 @@ module MonoCheck
   end
 end
 
-git_status = MonoCheck.run("git status -s")
-if $?.success?
-  unless git_status.empty?
-    puts "ERROR: The mono repository has been modified locally. " \
-      "You are using the `mono` executable which is only meant for " \
-      "'production' use."
-    puts "Please use the `mono-dev` executable if you want to use " \
-      "uncommitted changes to _test_ mono itself."
-    exit 1
-  end
-
-  current_branch = MonoCheck.run!("git rev-parse --abbrev-ref HEAD").chomp
-  unless current_branch == "main"
-    puts "ERROR: The mono repository is not on the `main` branch. " \
-      "Please switch to the main branch to ensure you're using a released " \
-      "version."
-    puts "Please use the `mono-dev` executable if you want to use " \
-      "uncommitted changes to _test_ mono itself."
-    exit 1
-  end
-
-  repository_root = MonoCheck.run!("git rev-parse --show-toplevel").chomp
-  fetch_head = File.join(repository_root, ".git", "FETCH_HEAD")
+def check_for_updates
+  fetch_head = File.expand_path("../.git/FETCH_HEAD", __dir__)
 
   last_modified = File.exist?(fetch_head) ? File.mtime(fetch_head) : Time.at(0)
   if Time.now - last_modified > CHECK_FOR_UPDATES_AFTER
     puts "Checking for updates..."
     previous_version = MonoCheck.run!("git rev-parse --short HEAD").chomp
+
     fetch_output = MonoCheck.run("git fetch origin main")
     if $?.success?
       MonoCheck.run!("git reset --hard origin/main")
@@ -62,13 +42,39 @@ if $?.success?
       else
         puts "Updated Mono to the latest version " \
           "(#{previous_version} -> #{latest_version})"
-        exec File.join(__dir__, "mono"), *ARGV
+        exec File.join(__dir__, "mono"), *ARGV # Restart with the new version
       end
     else
-      puts "WARNING: Could not check for updates (#{fetch_output.chomp})"
+      puts "WARNING: Could not check for updates:\n#{fetch_output.chomp}"
       puts "Continuing with current version."
     end
     puts
+  end
+end
+
+if ENV["MONO_DEV"].nil?
+  git_status = MonoCheck.run("git status -s")
+  if $?.success?
+    unless git_status.empty?
+      puts "ERROR: The mono repository has been modified locally. " \
+        "You are using the `mono` executable which is only meant for " \
+        "'production' use."
+      puts "Please use the `mono-dev` executable if you want to use " \
+        "uncommitted changes to _test_ mono itself."
+      exit 1
+    end
+
+    current_branch = MonoCheck.run!("git rev-parse --abbrev-ref HEAD").chomp
+    unless current_branch == "main"
+      puts "ERROR: The mono repository is not on the `main` branch. " \
+        "Please switch to the main branch to ensure you're using a released " \
+        "version."
+      puts "Please use the `mono-dev` executable if you want to use " \
+        "uncommitted changes to _test_ mono itself."
+      exit 1
+    end
+
+    check_for_updates
   end
 end
 

--- a/lib/mono/cli.rb
+++ b/lib/mono/cli.rb
@@ -125,7 +125,7 @@ module Mono
         command = @options.shift
         case command
         when "init"
-          Mono::Cli::Init.new.execute
+          Mono::Cli::Init.new(init_options).execute
         when "bootstrap"
           Mono::Cli::Bootstrap.new(bootstrap_options).execute
         when "unbootstrap"
@@ -204,8 +204,22 @@ module Mono
           end
 
           o.separator ""
+          o.separator "Run `mono <command> --help` for command-specific help."
           o.separator "Available commands: #{AVAILABLE_COMMANDS.join(", ")}"
+
+          if @options.empty?
+            puts o
+            exit_cli_with_status 1
+          end
         end.order!(@options)
+      end
+
+      def init_options
+        params = {}
+        OptionParser.new do |opts|
+          opts.banner = "Usage: mono init"
+        end.parse(@options)
+        params
       end
 
       def bootstrap_options
@@ -224,7 +238,7 @@ module Mono
       def unbootstrap_options
         params = {}
         OptionParser.new do |opts|
-          opts.banner = "Usage: mono unbootstrap [options]"
+          opts.banner = "Usage: mono unbootstrap"
         end.parse(@options)
         params
       end

--- a/lib/mono/cli/init.rb
+++ b/lib/mono/cli/init.rb
@@ -5,6 +5,10 @@ module Mono
     class Init
       include Shell
 
+      def initialize(options = {})
+        @options = options
+      end
+
       def execute
         config = {}
         puts "Initializing project..."


### PR DESCRIPTION
### [Improve help output](https://github.com/appsignal/mono/commit/fe09cee592f293f81e29ad6430c41c7628f20311)

When printing the help output (`mono --help`) also point out that
`mono <command> --help` can be used to obtain help about each
specific command.

When calling `mono` without any arguments, print the help as in
`mono --help`, but exit with a non-zero status code. This is the
behaviour of other tools with subcommand-based CLIs such as `git`.

Make `mono init` react to `--help` like other commands. When a
command accepts no arguments, do not add `[options]` to its usage
section.

### [Add auto-update functionality](https://github.com/appsignal/mono/commit/f9942d7fe273666da36b46aa2441e4f7228f5806)

When launching `mono`, check for updates by attempting to fetch the
`origin` remote in the repository. If an update is found, reset the
repository to the state in the remote, and restart Mono by replacing
the current process with a new `bin/mono` invocation.

Only attempt to check for updates if it has not been checked for
updates in the last 24 hours. Ensure that failure to check for updates
(e.g. no internet connection) does not cause Mono to crash.

### [Add MONO_DEV environment variable](https://github.com/appsignal/mono/commit/bee14cd644bd8ed0606bb1af8c900cda8600f373)

Add a `MONO_DEV` environment variable that, when set, causes `mono`
to behave like `mono-dev` -- that is, it does not refuse to run if
the code has been modified, and it does not attempt to auto-update.
This is useful in scenarios where the invocation of `mono` under test
is itself performed by another tool, such as in the AppSignal agent's
release scripts.

Also move the code around to avoid having three levels of nesting,
making RuboCop and future readers happy.