### PR TITLE
List multiple commits in changelog per entry

### DIFF
--- a/.changesets/list-all-relevant-commits-in-changelog.md
+++ b/.changesets/list-all-relevant-commits-in-changelog.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+List all relevant commits for a changeset in the changelog. If a changeset is modified in multiple commits, list them all.

--- a/.changesets/skip-commtis-for-changeset-commit-sha.md
+++ b/.changesets/skip-commtis-for-changeset-commit-sha.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Allow ignoring commits that modify changesets. When a commit that modifies a changeset, add the `[skip mono]` tag to not have it be linked in the generated changelog as the relevant change. For example, when updating the changeset to fix a typo after it's been merged, add `[skip mono]` to the "Fix typo" commit to not link to that commit in the changelog.

--- a/lib/mono/changeset.rb
+++ b/lib/mono/changeset.rb
@@ -135,28 +135,29 @@ module Mono
     end
 
     def date
-      commit[:date]
+      commits.first[:date]
     end
 
-    def commit
-      @commit ||=
+    def commits
+      @commits ||=
         begin
           escaped_path = path.gsub('"', '\"')
           cmd = <<~COMMAND
             git log \
-              -n 1 \
               --pretty="format:%h %H %cI" \
             --grep="\\[skip mono\\]" \
               --invert-grep \
               -- "#{escaped_path}"
           COMMAND
           git_log = `#{cmd}`
-          short, long, date = git_log.split(" ")
-          {
-            :short => short,
-            :long => long,
-            :date => Time.parse(date)
-          }
+          git_log.split("\n").map do |line|
+            short, long, date = line.split(" ")
+            {
+              :short => short,
+              :long => long,
+              :date => Time.parse(date)
+            }
+          end
         end
     end
 
@@ -174,8 +175,8 @@ module Mono
       @date ||= Time.now
     end
 
-    def commit
-      # noop
+    def commits
+      []
     end
 
     def remove

--- a/lib/mono/changeset.rb
+++ b/lib/mono/changeset.rb
@@ -142,8 +142,15 @@ module Mono
       @commit ||=
         begin
           escaped_path = path.gsub('"', '\"')
-          git_log =
-            `git log -n 1 --pretty="format:%h %H %cI" -- "#{escaped_path}"`
+          cmd = <<~COMMAND
+            git log \
+              -n 1 \
+              --pretty="format:%h %H %cI" \
+            --grep="\\[skip mono\\]" \
+              --invert-grep \
+              -- "#{escaped_path}"
+          COMMAND
+          git_log = `#{cmd}`
           short, long, date = git_log.split(" ")
           {
             :short => short,

--- a/lib/mono/changeset_collection.rb
+++ b/lib/mono/changeset_collection.rb
@@ -94,13 +94,13 @@ module Mono
           else
             " "
           end
-        message << "(#{changeset.bump}"
-        commit = changeset.commit
-        if commit
+        commits = []
+        changeset.commits.reverse_each do |commit|
           url = "#{config.repo}/commit/#{commit[:long]}"
-          message << " [#{commit[:short]}](#{url})"
+          commits << "[#{commit[:short]}](#{url})"
         end
-        message << ")"
+        formatted_commits = " #{commits.join(", ")}" if commits.any?
+        message << "(#{changeset.bump}#{formatted_commits})"
       end
       message << "\n"
       message.join

--- a/spec/lib/mono/changeset_spec.rb
+++ b/spec/lib/mono/changeset_spec.rb
@@ -283,7 +283,9 @@ RSpec.describe Mono::Changeset do
         path = add_changeset :patch
 
         changeset = described_class.parse(path)
-        commit = changeset.commit
+        commits = changeset.commits
+        expect(commits.length).to eq(1)
+        commit = commits.first
         expect(commit).to match(
           :date => kind_of(Time),
           :long => kind_of(String),
@@ -301,7 +303,9 @@ RSpec.describe Mono::Changeset do
         path = add_changeset :patch, :filename => "Patch, & \"messagé'"
 
         changeset = described_class.parse(path)
-        commit = changeset.commit
+        commits = changeset.commits
+        expect(commits.length).to eq(1)
+        commit = commits.first
         expect(commit).to match(
           :date => kind_of(Time),
           :long => kind_of(String),
@@ -314,18 +318,44 @@ RSpec.describe Mono::Changeset do
     end
 
     context "with multiple commits" do
+      it "returns a list of multiple commit hashes" do
+        prepare_project :nodejs_npm_single
+        in_project do
+          path = add_changeset :patch, :filename => "the-changeset.md"
+          first_commit = commit_sha
+          File.open(path, "a+") { |f| f.write "Other changeset text" }
+          commit_changeset
+          second_commit = commit_sha
+
+          changeset = described_class.parse(path)
+          commits = changeset.commits
+          expect(commits.length).to eq(2)
+
+          expect(commits[0]).to include(
+            :date => kind_of(Time),
+            :long => second_commit,
+            :short => second_commit[0..6]
+          )
+          expect(commits[1]).to include(
+            :date => kind_of(Time),
+            :long => first_commit,
+            :short => first_commit[0..6]
+          )
+        end
+      end
+
       it "returns a hash with the relevant commit metadata" do
         prepare_project :nodejs_npm_single
         in_project do
           path = add_changeset :patch, :filename => "the-changeset.md"
-          File.open(path, "a+") do |f|
-            f.write "Other changeset text"
-          end
-          commit_long = `git rev-parse HEAD`.chomp
+          File.open(path, "a+") { |f| f.write "Other changeset text" }
+          commit_long = commit_sha
           commit_changes("Improve changeset text\n\n[skip mono]")
 
           changeset = described_class.parse(path)
-          commit = changeset.commit
+          commits = changeset.commits
+          expect(commits.length).to eq(1)
+          commit = commits.first
           expect(commit).to include(
             :date => kind_of(Time),
             :long => commit_long,

--- a/spec/support/helpers/git_helper.rb
+++ b/spec/support/helpers/git_helper.rb
@@ -10,6 +10,10 @@ module GitHelper
     local_changes.any?
   end
 
+  def commit_sha
+    `git rev-parse HEAD`.chomp
+  end
+
   def commit_count
     run_command "git rev-list --count HEAD"
   end


### PR DESCRIPTION
## Ignore commits that modify changesets

I pushed a release after I changed some changesets to fix typos and improve the changeset copy. Now when someone links to the relevant change in the changelog they are linked to that "improve changeset copy" commit. That's not the best experience. A `[skip mono]` tag in a commit message will have Mono ignore that commit and link to the previous commit that changed/created the changeset file.

## List multiple commits in changelog per entry

When I changed a changeset entry's text I inadvertently made the changelog link to that commit, rather than the relevant change. If there are multiple changes to the changeset, list them all in the changelog.

This will help identify all related changes if the changeset was changed multiple times, for example to fix a typo. Preferably it would also use the "skip mono" tag introduced the previous commit, but this way no changes are missed.
