### PR TITLE
Fix bug for changesets without commit

### DIFF
--- a/.changesets/fix-error-on-changeset-without-commit.md
+++ b/.changesets/fix-error-on-changeset-without-commit.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix an error being raised for changesets without commit.

--- a/lib/mono/changeset.rb
+++ b/lib/mono/changeset.rb
@@ -135,7 +135,8 @@ module Mono
     end
 
     def date
-      commits.first[:date]
+      commit = commits.first
+      commit ? commit[:date] : nil
     end
 
     def commits

--- a/spec/lib/mono/changeset_collection_spec.rb
+++ b/spec/lib/mono/changeset_collection_spec.rb
@@ -372,6 +372,26 @@ RSpec.describe Mono::ChangesetCollection do
         CHANGELOG
       end
     end
+
+    it "links to no commit if there are none" do
+      prepare_ruby_project do
+        create_ruby_package_files :name => "mygem", :version => "1.2.3"
+
+        add_changeset :patch, :type => :deprecate, :commit => false
+        commit_changeset "[skip mono]"
+      end
+
+      in_project do
+        collection.write_changesets_to_changelog
+        changelog = normalize_changelog(read_changelog_file)
+        puts changelog
+        expect(changelog).to include(<<~CHANGELOG)
+          ### Deprecated
+
+          - This is a patch changeset bump. (patch)
+        CHANGELOG
+      end
+    end
   end
 
   def normalize_changelog(content)

--- a/spec/lib/mono/changeset_spec.rb
+++ b/spec/lib/mono/changeset_spec.rb
@@ -368,4 +368,25 @@ RSpec.describe Mono::Changeset do
       end
     end
   end
+
+  describe "#date" do
+    it "returns the commit date" do
+      prepare_ruby_project do
+        path = add_changeset :patch
+
+        changeset = described_class.parse(path)
+        expect(changeset.date).to be_kind_of(Time)
+      end
+    end
+
+    it "returns nil if no valid commit is found" do
+      prepare_ruby_project do
+        path = add_changeset :patch, :commit => false
+        commit_changeset("[skip mono]")
+
+        changeset = described_class.parse(path)
+        expect(changeset.date).to be_nil
+      end
+    end
+  end
 end

--- a/spec/support/helpers/changeset_helper.rb
+++ b/spec/support/helpers/changeset_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ChangesetHelper
-  def add_changeset(bump, type: :add, message: nil, filename: nil)
+  def add_changeset(bump, type: :add, message: nil, filename: nil, commit: true)
     @changeset_count ||= 0
     @changeset_count += 1
     FileUtils.mkdir_p(".changesets")
@@ -18,7 +18,7 @@ module ChangesetHelper
     end
     message ||= "This is a #{bump} changeset bump."
     File.write(path, "#{metadata}#{message}")
-    commit_changeset("Changeset #{@changeset_count} #{bump}")
+    commit_changeset("Changeset #{@changeset_count} #{bump}") if commit
     path
   end
 


### PR DESCRIPTION
I made a commit that added a _new_ changeset and used the "skip mono" tag. Mono then raised error when it tried to fetch the commit's date when there was none. Fix this by falling back on `nil`. The order doesn't matter too much. The date the option fallback for the sort.

[skip review]