### PR TITLE
Improve changelog entry for final version

### DIFF
--- a/.changesets/add-final-changeset-to-all-pre-release-packages.md
+++ b/.changesets/add-final-changeset-to-all-pre-release-packages.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Add the 'final' changeset to all pre-release packages that are published when a new final release is made. Previously, only the pre-release packages without any changesets would get this changeset added.

--- a/.changesets/improve-final-changeset-text-.md
+++ b/.changesets/improve-final-changeset-text-.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Improve the changeset text for packages that are bumped from a pre-release to a final release. It will now mention more changes can be found in the pre-release changelog entries.

--- a/lib/mono/package.rb
+++ b/lib/mono/package.rb
@@ -49,7 +49,8 @@ module Mono
     def bump_version_to_final
       changesets.changesets << MemoryChangeset.new(
         { "bump" => current_version.current_bump, "type" => "change" },
-        "Package release."
+        "Release the final package version. " \
+          "See the pre-release changelog entries for the changes in this version."
       )
     end
 

--- a/lib/mono/package.rb
+++ b/lib/mono/package.rb
@@ -17,6 +17,10 @@ module Mono
       end
     end
 
+    FINAL_CHANGESET_MESSAGE = "Release the final package version. " \
+      "See the pre-release changelog entries for the changes in " \
+      "this version."
+
     include Command::Helper
 
     attr_reader :path, :name
@@ -49,8 +53,7 @@ module Mono
     def bump_version_to_final
       changesets.changesets << MemoryChangeset.new(
         { "bump" => current_version.current_bump, "type" => "change" },
-        "Release the final package version. " \
-          "See the pre-release changelog entries for the changes in this version."
+        FINAL_CHANGESET_MESSAGE
       )
     end
 

--- a/lib/mono/package_promoter.rb
+++ b/lib/mono/package_promoter.rb
@@ -32,7 +32,7 @@ module Mono
           # This covers the scenario where you did a prerelease, no further
           # fixes/changes are needed and the latest prerelease will become the
           # final release.
-          if updated_packages.empty? && !prerelease?
+          unless prerelease?
             packages.each do |package|
               next unless package.current_version.prerelease?
 

--- a/spec/lib/mono/cli/publish/base_spec.rb
+++ b/spec/lib/mono/cli/publish/base_spec.rb
@@ -515,7 +515,12 @@ RSpec.describe Mono::Cli::Publish do
 
         changelog = read_changelog_file
         expect_changelog_to_include_version_header(changelog, next_version)
-        expect_changelog_to_include_message(changelog, :patch, "Package release.")
+        expect_changelog_to_include_message(
+          changelog,
+          :patch,
+          "Release the final package version. " \
+            "See the pre-release changelog entries for the changes in this version."
+        )
 
         expect(local_changes?).to be_falsy, local_changes.inspect
         expect(commited_files).to eql([

--- a/spec/lib/mono/package_promoter_spec.rb
+++ b/spec/lib/mono/package_promoter_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe Mono::PackagePromoter do
         package_one = nodejs_package("one")
         promoter = build_promoter([package_one])
         expect(promoter.changed_packages).to contain_exactly(package_one)
+        expect_package_to_contain_release_changeset(package_one)
         update_packages(promoter.changed_packages)
 
         package_one = nodejs_package("one")
@@ -164,6 +165,7 @@ RSpec.describe Mono::PackagePromoter do
           end
           create_package "c" do
             create_package_json :name => "c", :version => "2.1.1-beta.10"
+            add_changeset :patch
           end
         end
         package_a = nodejs_package("a")
@@ -171,6 +173,10 @@ RSpec.describe Mono::PackagePromoter do
         package_c = nodejs_package("c")
         promoter = build_promoter([package_a, package_b, package_c])
         expect(promoter.changed_packages).to contain_exactly(package_a, package_b, package_c)
+
+        expect_package_to_contain_release_changeset(package_a)
+        expect_package_to_contain_release_changeset(package_b)
+        expect_package_to_contain_release_changeset(package_c)
         update_packages(promoter.changed_packages)
 
         package_a = nodejs_package("a")
@@ -195,6 +201,8 @@ RSpec.describe Mono::PackagePromoter do
         package_b = nodejs_package("b")
         promoter = build_promoter([package_a, package_b])
         expect(promoter.changed_packages).to contain_exactly(package_a, package_b)
+        expect_package_to_contain_release_changeset(package_a)
+        expect_package_to_contain_release_changeset(package_b)
         update_packages(promoter.changed_packages)
 
         package_a = nodejs_package("a")
@@ -217,6 +225,8 @@ RSpec.describe Mono::PackagePromoter do
         package_b = nodejs_package("b")
         promoter = build_promoter([package_a, package_b])
         expect(promoter.changed_packages).to contain_exactly(package_a, package_b)
+        expect_package_to_contain_release_changeset(package_a)
+        expect_package_to_not_contain_release_changeset(package_b)
         update_packages(promoter.changed_packages)
 
         package_a = nodejs_package("a")
@@ -238,5 +248,17 @@ RSpec.describe Mono::PackagePromoter do
 
   def update_packages(packages)
     packages.each(&:update_spec)
+  end
+
+  def expect_package_to_contain_release_changeset(package)
+    expect(package.changesets.changesets.map(&:message)).to include(
+      Mono::PackageBase::FINAL_CHANGESET_MESSAGE
+    )
+  end
+
+  def expect_package_to_not_contain_release_changeset(package)
+    expect(package.changesets.changesets.map(&:message)).to_not include(
+      Mono::PackageBase::FINAL_CHANGESET_MESSAGE
+    )
   end
 end


### PR DESCRIPTION
## Improve changelog entry for final version

When a pre-release version was published before the final version, but there are no new changeset entries, a changeset is added mentioning it's only bumped to the final release version.

Improve the text for this changeset so it's a bit more descriptive what it's about.

## Add final changeset to every pre-release package

When a package's current version is a pre-release, add the final changeset message indicating more changes are listed in the pre-release changelogs. Not just for packages that didn't have any other changes.

[skip review]
