### PR TITLE
Fix changeset without valid date

### DIFF
--- a/lib/mono/changeset.rb
+++ b/lib/mono/changeset.rb
@@ -136,7 +136,7 @@ module Mono
 
     def date
       commit = commits.first
-      commit ? commit[:date] : nil
+      commit ? commit[:date] : Time.at(0)
     end
 
     def commits

--- a/spec/lib/mono/changeset_spec.rb
+++ b/spec/lib/mono/changeset_spec.rb
@@ -379,13 +379,13 @@ RSpec.describe Mono::Changeset do
       end
     end
 
-    it "returns nil if no valid commit is found" do
+    it "returns a Time of 0 if no valid commit is found" do
       prepare_ruby_project do
         path = add_changeset :patch, :commit => false
         commit_changeset("[skip mono]")
 
         changeset = described_class.parse(path)
-        expect(changeset.date).to be_nil
+        expect(changeset.date).to eq(Time.at(0))
       end
     end
   end


### PR DESCRIPTION
A changeset can have no date if all commits that created and changed it have the `skip mono` tag in it. If this happens, return a valid Time object so we can compare dates, but set it to 0. This will make it appear last in the changelog.

[skip changeset]
[skip review]