### PR TITLE
Push tags one at a time

### DIFF
--- a/.changesets/push-git-tags-one-at-a-time.md
+++ b/.changesets/push-git-tags-one-at-a-time.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix an issue where, when more than three version tags are published for the same repository, Github Actions does not trigger the push event for any of the tags.

--- a/lib/mono/cli/publish.rb
+++ b/lib/mono/cli/publish.rb
@@ -274,8 +274,10 @@ module Mono
         run_hooks("git-publish", "pre")
         puts "# Publishing to Git"
         puts "## Pushing to Git remote origin"
-        package_versions = packages.map(&:next_tag).join(" ")
-        run_command "git push origin #{current_branch} #{package_versions}"
+        run_command "git push origin #{current_branch}"
+        packages.map(&:next_tag).each do |package_version|
+          run_command "git push origin #{package_version}"
+        end
         run_hooks("git-publish", "post")
       end
 

--- a/spec/lib/mono/cli/publish/base_spec.rb
+++ b/spec/lib/mono/cli/publish/base_spec.rb
@@ -257,7 +257,8 @@ RSpec.describe Mono::Cli::Publish do
         ],
         [project_dir, version_tag_command(tag, tmp_changelog_file)],
         [project_dir, "gem push mygem-#{next_version}.gem"],
-        [project_dir, "git push origin main #{tag}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin #{tag}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -376,7 +377,8 @@ RSpec.describe Mono::Cli::Publish do
         ],
         [project_dir, version_tag_command(tag)],
         [project_dir, "gem push mygem-#{next_version}.gem"],
-        [project_dir, "git push origin main #{tag}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin #{tag}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -429,7 +431,8 @@ RSpec.describe Mono::Cli::Publish do
         ],
         [project_dir, version_tag_command(tag)],
         [project_dir, "gem push mygem-#{next_version}.gem"],
-        [project_dir, "git push origin main #{tag}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin #{tag}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -484,7 +487,8 @@ RSpec.describe Mono::Cli::Publish do
         ],
         [project_dir, version_tag_command(tag)],
         [project_dir, "gem push mygem-#{next_version}.gem"],
-        [project_dir, "git push origin main #{tag}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin #{tag}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -540,7 +544,8 @@ RSpec.describe Mono::Cli::Publish do
         ],
         [project_dir, version_tag_command(tag)],
         [project_dir, "gem push mygem-#{next_version}.gem"],
-        [project_dir, "git push origin main #{tag}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin #{tag}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -611,7 +616,8 @@ RSpec.describe Mono::Cli::Publish do
         [project_dir, "echo before publish"],
         [project_dir, "gem push mygem-#{next_version}.gem"],
         [project_dir, "echo after publish"],
-        [project_dir, "git push origin main #{tag}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin #{tag}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -649,7 +655,8 @@ RSpec.describe Mono::Cli::Publish do
         ],
         [project_dir, version_tag_command(tag, tmp_changelog_file)],
         [project_dir, "gem push #{project_package_path(:package_a)}/package_a-#{next_version}.gem"],
-        [project_dir, "git push origin main #{tag}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin #{tag}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -695,7 +702,9 @@ RSpec.describe Mono::Cli::Publish do
         [project_dir, version_tag_command(tag2, package_b_changelog_file)],
         [project_dir, "gem push #{project_package_path(:package_a)}/package_a-#{next_version}.gem"],
         [project_dir, "gem push #{project_package_path(:package_b)}/package_b-#{next_version}.gem"],
-        [project_dir, "git push origin main #{tag1} #{tag2}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin #{tag1}"],
+        [project_dir, "git push origin #{tag2}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -853,7 +862,8 @@ RSpec.describe Mono::Cli::Publish do
         ],
         [project_dir, version_tag_command(tag)],
         [project_dir, "gem push mygem-#{next_version}.gem"],
-        [project_dir, "git push origin main #{tag}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin #{tag}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -910,7 +920,8 @@ RSpec.describe Mono::Cli::Publish do
             "-m 'Update version number and CHANGELOG.md.'"
         ],
         [project_dir, version_tag_command(tag)],
-        [project_dir, "git push origin main #{tag}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin #{tag}"]
       ])
       expect(exit_status).to eql(0), output
     end

--- a/spec/lib/mono/cli/publish/custom_spec.rb
+++ b/spec/lib/mono/cli/publish/custom_spec.rb
@@ -58,7 +58,8 @@ RSpec.describe Mono::Cli::Publish do
       ],
       [project_dir, version_tag_command(tag)],
       [project_dir, "echo publish"],
-      [project_dir, "git push origin main #{tag}"]
+      [project_dir, "git push origin main"],
+      [project_dir, "git push origin #{tag}"]
     ])
     expect(exit_status).to eql(0), output
   end

--- a/spec/lib/mono/cli/publish/elixir_spec.rb
+++ b/spec/lib/mono/cli/publish/elixir_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe Mono::Cli::Publish do
         ],
         [project_dir, version_tag_command(tag)],
         [project_dir, "mix hex.publish package --yes"],
-        [project_dir, "git push origin main v#{next_version}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin v#{next_version}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -103,7 +104,8 @@ RSpec.describe Mono::Cli::Publish do
         ],
         [project_dir, version_tag_command(tag)],
         [project_dir, "mix hex.publish package --yes"],
-        [project_dir, "git push origin main #{tag}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin #{tag}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -165,7 +167,8 @@ RSpec.describe Mono::Cli::Publish do
         ],
         [project_dir, version_tag_command(tag, tmp_changelog_file_for("package_a"))],
         [package_dir_a, "mix hex.publish package --yes"],
-        [project_dir, "git push origin main #{tag}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin #{tag}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -242,7 +245,9 @@ RSpec.describe Mono::Cli::Publish do
         [project_dir, version_tag_command(tag_b, tmp_changelog_file_for("package_b"))],
         [package_dir_a, "mix hex.publish package --yes"],
         [package_dir_b, "mix hex.publish package --yes"],
-        [project_dir, "git push origin main #{tag_a} #{tag_b}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin #{tag_a}"],
+        [project_dir, "git push origin #{tag_b}"]
       ])
       expect(exit_status).to eql(0), output
     end

--- a/spec/lib/mono/cli/publish/nodejs_spec.rb
+++ b/spec/lib/mono/cli/publish/nodejs_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe Mono::Cli::Publish do
           ],
           [project_dir, version_tag_command(tag, tmp_changelog_file_for("my_package"))],
           [project_dir, "npm publish"],
-          [project_dir, "git push origin main #{tag}"]
+          [project_dir, "git push origin main"],
+          [project_dir, "git push origin #{tag}"]
         ])
         expect(exit_status).to eql(0), output
       end
@@ -87,7 +88,8 @@ RSpec.describe Mono::Cli::Publish do
           ],
           [project_dir, version_tag_command(tag, tmp_changelog_file_for("my_package"))],
           [project_dir, "npm publish --tag alpha"],
-          [project_dir, "git push origin main #{tag}"]
+          [project_dir, "git push origin main"],
+          [project_dir, "git push origin #{tag}"]
         ])
         expect(exit_status).to eql(0), output
       end
@@ -124,7 +126,8 @@ RSpec.describe Mono::Cli::Publish do
           ],
           [project_dir, version_tag_command(tag, tmp_changelog_file_for("my_package"))],
           [project_dir, "npm publish --tag beta"],
-          [project_dir, "git push origin main #{tag}"]
+          [project_dir, "git push origin main"],
+          [project_dir, "git push origin #{tag}"]
         ])
         expect(exit_status).to eql(0), output
       end
@@ -162,7 +165,8 @@ RSpec.describe Mono::Cli::Publish do
           ],
           [project_dir, version_tag_command(tag, tmp_changelog_file_for("my_package"))],
           [project_dir, "npm publish --tag #{package_tag}"],
-          [project_dir, "git push origin main #{tag}"]
+          [project_dir, "git push origin main"],
+          [project_dir, "git push origin #{tag}"]
         ])
         expect(exit_status).to eql(0), output
       end
@@ -199,7 +203,8 @@ RSpec.describe Mono::Cli::Publish do
           ],
           [project_dir, version_tag_command(tag, tmp_changelog_file_for("my_package"))],
           [project_dir, "npm publish --tag rc"],
-          [project_dir, "git push origin main #{tag}"]
+          [project_dir, "git push origin main"],
+          [project_dir, "git push origin #{tag}"]
         ])
         expect(exit_status).to eql(0), output
       end
@@ -264,7 +269,8 @@ RSpec.describe Mono::Cli::Publish do
           ],
           [project_dir, version_tag_command(tag, tmp_changelog_file_for("package_one"))],
           [package_one_dir, "npm publish"],
-          [project_dir, "git push origin main #{tag}"]
+          [project_dir, "git push origin main"],
+          [project_dir, "git push origin #{tag}"]
         ])
         expect(exit_status).to eql(0), output
       end
@@ -357,7 +363,9 @@ RSpec.describe Mono::Cli::Publish do
           ],
           [package_one_dir, "npm publish"],
           [package_two_dir, "npm publish"],
-          [project_dir, "git push origin main #{package_one_tag} #{package_two_tag}"]
+          [project_dir, "git push origin main"],
+          [project_dir, "git push origin #{package_one_tag}"],
+          [project_dir, "git push origin #{package_two_tag}"]
         ])
         expect(exit_status).to eql(0), output
       end
@@ -500,7 +508,10 @@ RSpec.describe Mono::Cli::Publish do
           [package_dir_a, "npm publish"],
           [package_dir_b, "npm publish"],
           [package_dir_c, "npm publish"],
-          [project_dir, "git push origin main #{package_tag_a} #{package_tag_b} #{package_tag_c}"]
+          [project_dir, "git push origin main"],
+          [project_dir, "git push origin #{package_tag_a}"],
+          [project_dir, "git push origin #{package_tag_b}"],
+          [project_dir, "git push origin #{package_tag_c}"]
         ])
         expect(exit_status).to eql(0), output
       end
@@ -587,7 +598,9 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, version_tag_command(package_tag_b, tmp_changelog_file_for("package_b"))],
           [package_dir_a, "npm publish --tag alpha"],
           [package_dir_b, "npm publish --tag alpha"],
-          [project_dir, "git push origin main #{package_tag_a} #{package_tag_b}"]
+          [project_dir, "git push origin main"],
+          [project_dir, "git push origin #{package_tag_a}"],
+          [project_dir, "git push origin #{package_tag_b}"]
         ])
         expect(exit_status).to eql(0), output
       end
@@ -676,7 +689,9 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, version_tag_command(package_tag_b, tmp_changelog_file_for("package_b"))],
           [package_dir_a, "npm publish"],
           [package_dir_b, "npm publish"],
-          [project_dir, "git push origin main #{package_tag_a} #{package_tag_b}"]
+          [project_dir, "git push origin main"],
+          [project_dir, "git push origin #{package_tag_a}"],
+          [project_dir, "git push origin #{package_tag_b}"]
         ])
         expect(exit_status).to eql(0), output
       end
@@ -728,7 +743,8 @@ RSpec.describe Mono::Cli::Publish do
           ],
           [project_dir, version_tag_command(tag, tmp_changelog_file_for("my_package"))],
           [project_dir, "yarn publish --new-version #{next_version}"],
-          [project_dir, "git push origin main #{tag}"]
+          [project_dir, "git push origin main"],
+          [project_dir, "git push origin #{tag}"]
         ])
         expect(exit_status).to eql(0), output
       end

--- a/spec/lib/mono/cli/publish/ruby_spec.rb
+++ b/spec/lib/mono/cli/publish/ruby_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe Mono::Cli::Publish do
         ],
         [project_dir, version_tag_command(tag)],
         [project_dir, "gem push mygem-#{next_version}.gem"],
-        [project_dir, "git push origin main #{tag}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin #{tag}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -101,7 +102,8 @@ RSpec.describe Mono::Cli::Publish do
           [project_dir, version_tag_command(tag)],
           [project_dir, "gem push mygem-#{next_version}.gem"],
           [project_dir, "gem push mygem-#{next_version}-java.gem"],
-          [project_dir, "git push origin main #{tag}"]
+          [project_dir, "git push origin main"],
+          [project_dir, "git push origin #{tag}"]
         ])
         expect(exit_status).to eql(0), output
       end
@@ -153,7 +155,8 @@ RSpec.describe Mono::Cli::Publish do
         ],
         [project_dir, version_tag_command(tag)],
         [project_dir, "echo push"],
-        [project_dir, "git push origin main #{tag}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin #{tag}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -212,7 +215,8 @@ RSpec.describe Mono::Cli::Publish do
         ],
         [project_dir, version_tag_command(tag_a, tmp_changelog_file_for("package_a"))],
         [project_dir, "gem push packages/package_a/package_a-#{next_version_a}.gem"],
-        [project_dir, "git push origin main #{tag_a}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin #{tag_a}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -288,7 +292,9 @@ RSpec.describe Mono::Cli::Publish do
         [project_dir, version_tag_command(tag_b, tmp_changelog_file_for("package_b"))],
         [project_dir, "gem push packages/package_a/package_a-#{next_version_a}.gem"],
         [project_dir, "gem push packages/package_b/package_b-#{next_version_b}.gem"],
-        [project_dir, "git push origin main #{tag_a} #{tag_b}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin #{tag_a}"],
+        [project_dir, "git push origin #{tag_b}"]
       ])
       expect(exit_status).to eql(0), output
     end
@@ -389,7 +395,10 @@ RSpec.describe Mono::Cli::Publish do
         [project_dir, "gem push packages/package_a/package_a-#{next_version_a}.gem"],
         [project_dir, "gem push packages/package_b/package_b-#{next_version_b}.gem"],
         [project_dir, "gem push packages/package_c/package_c-#{next_version_c}.gem"],
-        [project_dir, "git push origin main #{tag_a} #{tag_b} #{tag_c}"]
+        [project_dir, "git push origin main"],
+        [project_dir, "git push origin #{tag_a}"],
+        [project_dir, "git push origin #{tag_b}"],
+        [project_dir, "git push origin #{tag_c}"]
       ])
       expect(exit_status).to eql(0), output
     end


### PR DESCRIPTION
This works around an issue where Github Actions will not trigger push events if more than three tags are pushed at once.