### PR TITLE
Show local changes in publish dirty-tree error

### DIFF
--- a/.changesets/show-local-changes-in-publish-error.md
+++ b/.changesets/show-local-changes-in-publish-error.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Show local file changes when `mono publish` exits due to a dirty git working tree.

--- a/lib/mono/cli.rb
+++ b/lib/mono/cli.rb
@@ -97,10 +97,14 @@ module Mono
         `git rev-parse --abbrev-ref HEAD`.chomp
       end
 
-      def local_changes?
+      def local_changes
         `git status -s -u`.split("\n").each do |change|
           change.gsub!(/^.. /, "")
-        end.any?
+        end
+      end
+
+      def local_changes?
+        local_changes.any?
       end
 
       def exit_cli(message)

--- a/lib/mono/cli/publish.rb
+++ b/lib/mono/cli/publish.rb
@@ -39,7 +39,8 @@ module Mono
 
         if local_changes?
           exit_cli "Error: There are local changes before building. " \
-            "Commit or discard them and try again. Exiting."
+            "Commit or discard them and try again. Exiting.\n" \
+            "#{local_changes.map { |c| "- #{c}" }.join("\n")}"
         end
 
         if git?

--- a/spec/lib/mono/cli/publish/base_spec.rb
+++ b/spec/lib/mono/cli/publish/base_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe Mono::Cli::Publish do
 
       expect(performed_commands).to be_empty
       expect(output).to include("Error: There are local changes before building.")
+      expect(output).to include("- uncommited_file")
       expect(exit_status).to eql(1), output
     end
   end


### PR DESCRIPTION
Improve the publish preflight failure output by listing changed files so users can quickly resolve the issue. Add a regression spec and a patch changeset for the behavior update.